### PR TITLE
Add RecursiveSerializer

### DIFF
--- a/src/meshapi/permissions.py
+++ b/src/meshapi/permissions.py
@@ -1,7 +1,10 @@
 import json
+from typing import Optional
 
 from django.conf import os
 from django.contrib.auth import PermissionDenied
+from django.contrib.auth.models import User
+from django.db.models import Model
 from rest_framework import permissions
 from rest_framework.permissions import BasePermission
 
@@ -47,3 +50,11 @@ class LegacyNNAssignmentPassword(permissions.BasePermission):
             return True
 
         raise PermissionDenied("Authentication Failed.")
+
+
+def check_has_model_view_permission(user: Optional[User], model: Model):
+    if not user:
+        # Unauthenticated requests do not have permission by default
+        return False
+
+    return user.has_perm(f"{__package__}.view_{model._meta.model_name}")

--- a/src/meshapi/serializers/model_api.py
+++ b/src/meshapi/serializers/model_api.py
@@ -1,7 +1,14 @@
+from typing import Optional
+
 from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+from rest_framework.fields import empty
+from rest_framework.serializers import raise_errors_on_nested_writes
 
 from meshapi.models import Building, Install, Member
+from meshapi.permissions import check_has_model_view_permission
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -10,19 +17,138 @@ class UserSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class BuildingSerializer(serializers.ModelSerializer):
+class RecursiveSerializer(serializers.ModelSerializer):
+    """
+    A serializer which follows foreign-key relationships when serializing, taking care to avoid
+    leaking data by checking user permissions as we recursively iterate through the objects. To
+    prevent infinite recursive loops, use the exclude_fields parameter to specify the field name
+    on this Serializer's model class which describes the "reverse" relationship back to the field
+    that this serializer is being called to fill. Don't specify it for "root" serialization requests
+
+    For de-serialization, we are able to accept either a data object which is a simple
+    primary key pointing to this class in the DB, or a complex object which will be created/updated
+    according the normal logic of the ModelSerializer class. However, we cannot accommodate nested
+    object creation or updating at this time. Make separate POST or PUT requests to accomplish this
+    """
+
+    default_error_messages = {
+        "required": _("This field is required."),
+        "does_not_exist": _('Invalid pk "{pk_value}" - object does not exist.'),
+        "incorrect_type": _("Incorrect type. Expected pk value, received {data_type}."),
+        "nesting_detected": _(
+            "Nested detected. Nesting is not permitted for write calls. Ensure all top-level fields are scalars"
+        ),
+    }
+
+    def __init__(self, instance=None, data=empty, exclude_fields=None, **kwargs):
+        super().__init__(instance, data, **kwargs)
+        if exclude_fields is None:
+            exclude_fields = []
+
+        self.excluded_fields = exclude_fields
+
+    def _field_is_excluded(self, field_name: str, user: Optional[User] = None):
+        # Remove explicitly excluded fields, this is primarily to prevent infinite recursive loops,
+        # though this logic could probably be generalized into an ExcludedFieldSerializer class
+        # if needed for other applications in the future
+        if field_name in self.excluded_fields:
+            return True
+
+        # Do permissions-based checks and mutate objects that the user does not have permission
+        # to access, so that they are reduced to only a pointer to a primary key
+        # e.g. if the user doesn't have access to the member model, when we serialize it for the
+        # Install model, it should look very empty:
+        #    "member": { "id": 1 }
+        # so that we do not leak data they do not have access to
+        if not check_has_model_view_permission(user, self.Meta.model):
+            if field_name != self.Meta.model._meta.pk.name:
+                return True
+
+        return False
+
+    def get_fields(self):
+        user = None
+        request = self.context.get("request", None)
+        if request:
+            user = request.user
+
+        output_fields = {}
+        for field_key, serializer in super().get_fields().items():
+            output_fields[field_key] = serializer
+
+        return {
+            field_key: serializer
+            for field_key, serializer in super().get_fields().items()
+            if not self._field_is_excluded(field_key, user)
+        }
+
+    def get_value(self, dictionary):
+        # Note that this might break Django HTML forms in some cases. However, we're not using those
+        # and we need to do this override because there appears to be a bug in how their detection
+        # logic for those forms works, and the HTML code path is running errantly
+        # See Serializer.get_value() for more info
+        return dictionary.get(self.field_name, empty)
+
+    def create(self, validated_data):
+        try:
+            raise_errors_on_nested_writes("create", self, validated_data)
+        except AssertionError:
+            self.fail("nesting_detected")
+
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        try:
+            raise_errors_on_nested_writes("update", self, validated_data)
+        except AssertionError:
+            self.fail("nesting_detected")
+
+        return super().update(instance, validated_data)
+
+    def to_internal_value(self, data):
+        # If this seems like a whole object, attempt to deserialize it using our parent's method
+        if isinstance(data, dict):
+            return super().to_internal_value(data)
+
+        # However if this is not a whole object, treat it as an PK and try to find it in our db
+        try:
+            if isinstance(data, bool):
+                raise TypeError
+            return self.Meta.model.objects.all().get(pk=data)
+        except ObjectDoesNotExist:
+            self.fail("does_not_exist", pk_value=data)
+        except (TypeError, ValueError):
+            self.fail("incorrect_type", data_type=type(data).__name__)
+
+
+class BuildingSerializer(RecursiveSerializer):
     class Meta:
         model = Building
         fields = "__all__"
 
+    # installs has been added below, scroll down to InstallSerializer to see it
 
-class MemberSerializer(serializers.ModelSerializer):
+
+class MemberSerializer(RecursiveSerializer):
     class Meta:
         model = Member
         fields = "__all__"
 
+    # installs has been added below, scroll down to InstallSerializer to see it
 
-class InstallSerializer(serializers.ModelSerializer):
+
+class InstallSerializer(RecursiveSerializer):
     class Meta:
         model = Install
         fields = "__all__"
+
+    member = MemberSerializer(exclude_fields=["installs"])
+    building = BuildingSerializer(exclude_fields=["installs"])
+
+
+# This is a bit hacky, but gets around the fact that we can't call InstallSerializer() until after
+# MemberSerializer has already been declared
+MemberSerializer._declared_fields["installs"] = InstallSerializer(exclude_fields=["member"], many=True, read_only=True)
+BuildingSerializer._declared_fields["installs"] = InstallSerializer(
+    exclude_fields=["building"], many=True, read_only=True
+)

--- a/src/meshapi/tests/sample_data.py
+++ b/src/meshapi/tests/sample_data.py
@@ -29,7 +29,7 @@ sample_install = {
     "install_date": "2022-03-01",
     "abandon_date": "9999-01-01",
     "building": 1,
-    "unit": 3,
+    "unit": "3",
     "roof_access": True,
     "member": 1,
     "notes": "Referral: Read about it on the internet",

--- a/src/meshapi/tests/test_recursive_views.py
+++ b/src/meshapi/tests/test_recursive_views.py
@@ -1,0 +1,333 @@
+import json
+
+from django.contrib.auth.models import Permission, User
+from django.test import Client, TestCase
+
+from meshapi.models import Building, Install, Member
+from meshapi.tests.sample_data import sample_building, sample_install, sample_member
+
+
+def setup_objects():
+    member_obj = Member(id=1, **sample_member)
+    member_obj.save()
+    building = sample_building.copy()
+    building["primary_nn"] = None
+    building_obj = Building(id=1, **building)
+    building_obj.save()
+    inst = sample_install.copy()
+
+    if inst["abandon_date"] == "":
+        inst["abandon_date"] = None
+
+    inst["building"] = building_obj
+    inst["member"] = member_obj
+    inst["install_number"] = 2000
+    install_obj = Install(**inst)
+    install_obj.save()
+
+
+class TestViewsGetLimitedPermissions(TestCase):
+    c = Client()
+
+    def setUp(self):
+        # Create sample data
+        setup_objects()
+
+        self.no_member_perm_user = User.objects.create_user(
+            username="limited_install", password="password", email="installer@example.com"
+        )
+        self.no_member_perm_user.user_permissions.add(Permission.objects.get(codename="view_install"))
+        self.no_member_perm_user.user_permissions.add(Permission.objects.get(codename="view_building"))
+
+        self.no_install_perm_user = User.objects.create_user(
+            username="limited_member", password="password", email="installer@example.com"
+        )
+        self.no_install_perm_user.user_permissions.add(Permission.objects.get(codename="view_member"))
+        self.no_install_perm_user.user_permissions.add(Permission.objects.get(codename="view_building"))
+
+    def test_views_get_install(self):
+        self.c.login(username="limited_install", password="password")
+
+        response = self.c.get("/api/v1/installs/2000/").json()
+        self.assertEqual(response["unit"], "3")
+        self.assertEqual(
+            response["member"],
+            {
+                "id": 1,
+            },
+        )
+        self.assertEqual(
+            response["building"],
+            {
+                "id": 1,
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+
+        self.c.login(username="limited_member", password="password")
+
+        response = self.c.get("/api/v1/installs/1/")
+        self.assertEqual(response.status_code, 403)
+
+    def test_views_get_member(self):
+        self.c.login(username="limited_install", password="password")
+
+        response = self.c.get("/api/v1/members/1/")
+        self.assertEqual(response.status_code, 403)
+
+        self.c.login(username="limited_member", password="password")
+
+        response = self.c.get("/api/v1/members/1/").json()
+        self.assertEqual(response["email_address"], "john.smith@example.com")
+        self.assertEqual(
+            response["installs"],
+            [
+                {
+                    "install_number": 2000,
+                }
+            ],
+        )
+
+    def test_views_get_building(self):
+        self.c.login(username="limited_install", password="password")
+
+        response = self.c.get("/api/v1/buildings/1/").json()
+        self.assertEqual(response["bin"], 8888)
+        self.assertEqual(
+            response["installs"],
+            [
+                {
+                    "install_number": 2000,
+                    "member": {
+                        "id": 1,
+                    },
+                    "network_number": 2000,
+                    "install_status": "Active",
+                    "ticket_id": 69,
+                    "request_date": "2022-02-27",
+                    "install_date": "2022-03-01",
+                    "abandon_date": "9999-01-01",
+                    "unit": "3",
+                    "roof_access": True,
+                    "referral": None,
+                    "notes": "Referral: Read about it on the internet",
+                }
+            ],
+        )
+
+        self.c.login(username="limited_member", password="password")
+
+        response = self.c.get("/api/v1/buildings/1/").json()
+        self.assertEqual(response["bin"], 8888)
+        self.assertEqual(
+            response["installs"],
+            [
+                {
+                    "install_number": 2000,
+                }
+            ],
+        )
+
+
+class TestViewsGetAdmin(TestCase):
+    c = Client()
+
+    def setUp(self):
+        # Create sample data
+        setup_objects()
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+
+    def test_views_get_install(self):
+        self.c.login(username="admin", password="admin_password")
+
+        response = self.c.get("/api/v1/installs/2000/").json()
+        self.assertEqual(response["unit"], "3")
+        self.assertEqual(
+            response["member"],
+            {
+                "id": 1,
+                "name": "John Smith",
+                "email_address": "john.smith@example.com",
+                "stripe_email_address": None,
+                "secondary_emails": [],
+                "phone_number": "555-555-5555",
+                "slack_handle": "@jsmith",
+                "invalid": False,
+                "contact_notes": None,
+            },
+        )
+        self.assertEqual(
+            response["building"],
+            {
+                "id": 1,
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+
+    def test_views_get_member(self):
+        self.c.login(username="admin", password="admin_password")
+
+        response = self.c.get("/api/v1/members/1/").json()
+        self.assertEqual(response["email_address"], "john.smith@example.com")
+        self.assertEqual(
+            response["installs"],
+            [
+                {
+                    "install_number": 2000,
+                    "building": {
+                        "id": 1,
+                        "bin": 8888,
+                        "building_status": "Active",
+                        "street_address": "3333 Chom St",
+                        "city": "Brooklyn",
+                        "state": "NY",
+                        "zip_code": "11111",
+                        "invalid": False,
+                        "address_truth_sources": "['NYCPlanningLabs']",
+                        "latitude": 0.0,
+                        "longitude": 0.0,
+                        "altitude": 0.0,
+                        "primary_nn": None,
+                        "node_name": None,
+                        "notes": None,
+                    },
+                    "network_number": 2000,
+                    "install_status": "Active",
+                    "ticket_id": 69,
+                    "request_date": "2022-02-27",
+                    "install_date": "2022-03-01",
+                    "abandon_date": "9999-01-01",
+                    "unit": "3",
+                    "roof_access": True,
+                    "referral": None,
+                    "notes": "Referral: Read about it on the internet",
+                }
+            ],
+        )
+
+    def test_views_get_building(self):
+        self.c.login(username="admin", password="admin_password")
+
+        response = self.c.get("/api/v1/buildings/1/").json()
+        self.assertEqual(response["bin"], 8888)
+        self.assertEqual(
+            response["installs"],
+            [
+                {
+                    "install_number": 2000,
+                    "member": {
+                        "id": 1,
+                        "name": "John Smith",
+                        "email_address": "john.smith@example.com",
+                        "stripe_email_address": None,
+                        "secondary_emails": [],
+                        "phone_number": "555-555-5555",
+                        "slack_handle": "@jsmith",
+                        "invalid": False,
+                        "contact_notes": None,
+                    },
+                    "network_number": 2000,
+                    "install_status": "Active",
+                    "ticket_id": 69,
+                    "request_date": "2022-02-27",
+                    "install_date": "2022-03-01",
+                    "abandon_date": "9999-01-01",
+                    "unit": "3",
+                    "roof_access": True,
+                    "referral": None,
+                    "notes": "Referral: Read about it on the internet",
+                }
+            ],
+        )
+
+
+class TestViewsPutAdmin(TestCase):
+    c = Client()
+
+    def setUp(self):
+        # Create sample data
+        setup_objects()
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+
+    def test_views_put_new_install_with_pk(self):
+        self.c.login(username="admin", password="admin_password")
+
+        inst = sample_install.copy()
+
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+
+        inst["building"] = 1
+        inst["member"] = 1
+        inst["install_number"] = 2001
+
+        response = self.c.post("/api/v1/installs/", inst)
+        self.assertEqual(response.status_code, 201)
+
+        install = Install.objects.get(install_number=response.json()["install_number"])
+        self.assertEqual(install.member.id, 1)
+        self.assertEqual(install.member.email_address, "john.smith@example.com")
+        self.assertEqual(install.building.id, 1)
+        self.assertEqual(install.building.bin, 8888)
+
+    def test_views_post_new_install_with_nested_data_not_allowed(self):
+        self.c.login(username="admin", password="admin_password")
+
+        inst = sample_install.copy()
+
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+
+        inst["building"] = 1
+        inst["member"] = sample_member
+        inst["install_number"] = 2001
+
+        response = self.c.post("/api/v1/installs/", inst)
+        self.assertEqual(response.status_code, 400)
+
+    def test_views_put_install_with_nested_data_not_allowed(self):
+        self.c.login(username="admin", password="admin_password")
+
+        inst = sample_install.copy()
+
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+
+        inst["building"] = 1
+        inst["member"] = sample_member
+        inst["install_number"] = 2000
+
+        response = self.c.put("/api/v1/installs/2000/", json.dumps(inst), content_type="application/json")
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Adds a `RecursiveSerializer` class, which enables child serializers to provide recursive model serialization

Uses automatic permissions detection to determine if the user is authorized to access the foreign model, restricting the fields available to just the primary key if not