### PR TITLE
Fix: primary_nn and node_name are sometimes dropped for duplicate buildings

### DIFF
--- a/src/meshdb/utils/spreadsheet_import/main.py
+++ b/src/meshdb/utils/spreadsheet_import/main.py
@@ -121,11 +121,13 @@ def main():
     for spreadsheet_link in links:
         try:
             from_building = models.Building.objects.filter(
-                Q(install__install_number=spreadsheet_link.from_install_num)
+                Q(installs__install_number=spreadsheet_link.from_install_num)
+                | Q(installs__network_number=spreadsheet_link.from_install_num)
                 | Q(primary_nn=spreadsheet_link.from_install_num),
             )[0]
             to_building = models.Building.objects.filter(
-                Q(install__install_number=spreadsheet_link.to_install_num)
+                Q(installs__install_number=spreadsheet_link.to_install_num)
+                | Q(installs__network_number=spreadsheet_link.to_install_num)
                 | Q(primary_nn=spreadsheet_link.to_install_num),
             )[0]
         except IndexError:
@@ -183,7 +185,9 @@ def main():
     for spreadsheet_sector in sectors:
         try:
             building = models.Building.objects.filter(
-                Q(install__install_number=spreadsheet_sector.node_id) | Q(primary_nn=spreadsheet_sector.node_id),
+                Q(installs__install_number=spreadsheet_sector.node_id)
+                | Q(installs__network_number=spreadsheet_sector.node_id)
+                | Q(primary_nn=spreadsheet_sector.node_id),
             )[0]
         except IndexError:
             message = f"Could not find building for install {spreadsheet_sector.node_id}"

--- a/src/meshdb/utils/spreadsheet_import/parse_building.py
+++ b/src/meshdb/utils/spreadsheet_import/parse_building.py
@@ -218,6 +218,8 @@ def get_or_create_building(
                 city=address_result.address.city,
                 state=address_result.address.state,
                 zip_code=address_result.address.zip_code,
+                primary_nn=row.nn if row.nn else None,
+                node_name=row.nodeName if row.nodeName else None,
             ),
             add_dropped_edit,
         )


### PR DESCRIPTION
Found a bug in the import script that results in buildings with multiple rows not grabbing the NN from successive rows if the first row has a null value