### PR TITLE
Add KML generator endpoint & example KML files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "django-cors-headers==4.3.*",
     "nameparser==1.1.*",
     "inflect==7.0.*",
+    "fastkml[lxml]==1.a10", # Update me to stable, once 1.0 is released officially
 ]
 
 [project.optional-dependencies]

--- a/sampledata/meshdb.kml
+++ b/sampledata/meshdb.kml
@@ -1,0 +1,8 @@
+<NetworkLink>
+  <name>NYCMesh (from MeshDB)</name>
+  <flyToView>0</flyToView>
+  <Link>
+    <href>https://db.grandsvc.mesh.nycmesh.net/api/v1/geography/whole-mesh.kml</href>
+    <viewRefreshMode>onRequest</viewRefreshMode>
+  </Link>
+</NetworkLink>

--- a/sampledata/meshdb_local.kml
+++ b/sampledata/meshdb_local.kml
@@ -1,0 +1,8 @@
+<NetworkLink>
+  <name>NYCMesh (from MeshDB)</name>
+  <flyToView>0</flyToView>
+  <Link>
+    <href>http://127.0.0.1:8000/api/v1/geography/whole-mesh.kml</href>
+    <viewRefreshMode>onRequest</viewRefreshMode>
+  </Link>
+</NetworkLink>

--- a/src/meshapi/tests/test_kml_endpoint.py
+++ b/src/meshapi/tests/test_kml_endpoint.py
@@ -1,0 +1,132 @@
+import datetime
+import json
+
+from django.contrib.auth.models import Group, User
+from django.test import Client, TestCase
+from fastkml import kml
+from lxml import etree
+from rest_framework.authtoken.models import Token
+
+from meshapi.models import Building, Install, Link, Member, Sector
+
+
+def create_building_install_pair(member_ref, nn):
+    building = Building(
+        building_status=Building.BuildingStatus.ACTIVE,
+        address_truth_sources="",
+        latitude=0,
+        longitude=0,
+        altitude=0,
+        primary_nn=nn,
+    )
+    building.save()
+
+    install = Install(
+        member=member_ref,
+        building=building,
+        install_number=nn,
+        network_number=nn,
+        install_status=Install.InstallStatus.ACTIVE,
+        request_date=datetime.date.today(),
+    )
+    install.save()
+
+    return install, building
+
+
+class TestKMLEndpoint(TestCase):
+    c = Client()
+
+    def test_views_get_unauthenticated(self):
+        routes = [
+            ("/api/v1/geography/whole-mesh.kml", 200),
+        ]
+
+        for route, code in routes:
+            response = self.c.get(route)
+            self.assertEqual(
+                code,
+                response.status_code,
+                f"status code incorrect for GET {route}. Should be {code}, but got {response.status_code}",
+            )
+
+            response = self.c.options(route)
+            self.assertEqual(
+                code,
+                response.status_code,
+                f"status code incorrect for OPTIONS {route}. Should be {code}, but got {response.status_code}",
+            )
+
+    def test_kml_data(self):
+        links = []
+
+        fake_member = Member(name="Stacy Fakename")
+        fake_member.save()
+
+        grand_install, grand = create_building_install_pair(fake_member, 1934)
+        sn1_install, sn1 = create_building_install_pair(fake_member, 227)
+        sn10_install, sn10 = create_building_install_pair(fake_member, 10)
+        sn3_install, sn3 = create_building_install_pair(fake_member, 713)
+        brian_install, brian = create_building_install_pair(fake_member, 3)
+        random_install, random = create_building_install_pair(fake_member, 123)
+
+        links.append(
+            Link(
+                from_building=sn1,
+                to_building=sn3,
+                status=Link.LinkStatus.ACTIVE,
+                type=Link.LinkType.VPN,
+                install_date=datetime.date(2022, 1, 26),
+            )
+        )
+
+        links.append(
+            Link(
+                from_building=sn1,
+                to_building=grand,
+                status=Link.LinkStatus.ACTIVE,
+                type=Link.LinkType.MMWAVE,
+            )
+        )
+
+        links.append(
+            Link(
+                from_building=sn1,
+                to_building=brian,
+                status=Link.LinkStatus.ACTIVE,
+                type=Link.LinkType.STANDARD,
+            )
+        )
+
+        links.append(
+            Link(
+                from_building=grand,
+                to_building=sn10,
+                status=Link.LinkStatus.ACTIVE,
+                type=Link.LinkType.FIBER,
+            )
+        )
+
+        links.append(
+            Link(
+                from_building=grand,
+                to_building=random,
+                status=Link.LinkStatus.PLANNED,
+                type=Link.LinkType.STANDARD,
+            )
+        )
+
+        for link in links:
+            link.save()
+
+        self.maxDiff = None
+        response = self.c.get("/api/v1/geography/whole-mesh.kml")
+
+        kml_tree = etree.fromstring(response.content.decode("UTF8"))
+
+        # TODO: Actually assert real things here in a less brittle way,
+        #  once fastkml is actually capable of parsing its own outputs
+        assert len(kml_tree[0]) == 6  # 4 styles and 2 folders
+        assert len(kml_tree[0][4]) == 7  # 5 borough folders and "Other" + 1 for "name" tag
+        assert len(kml_tree[0][4][6]) == 7  # 6 nodes, all in the "Other" folder + 1 for "name" tag
+        assert len(kml_tree[0][5]) == 6  # 5 links + 1 for "name" tag

--- a/src/meshapi/urls.py
+++ b/src/meshapi/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("mapdata/installs/", views.MapDataInstallList.as_view(), name="meshapi-v1-map-data-installs"),
     path("mapdata/links/", views.MapDataLinkList.as_view(), name="meshapi-v1-map-data-links"),
     path("mapdata/sectors/", views.MapDataSectorlList.as_view(), name="meshapi-v1-map-data-sectors"),
+    path("geography/whole-mesh.kml", views.map_kml, name="meshapi-v1-geography-whole-mesh-kml"),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/meshapi/views/__init__.py
+++ b/src/meshapi/views/__init__.py
@@ -1,4 +1,5 @@
 from .forms import *
+from .geography import *
 from .lookups import *
 from .map import *
 from .model_api import *

--- a/src/meshapi/views/geography.py
+++ b/src/meshapi/views/geography.py
@@ -1,0 +1,171 @@
+from typing import Dict
+
+from django.db.models import F, Q
+from django.db.models.functions import Greatest
+from django.http import HttpResponse
+from fastkml import Data, ExtendedData, geometry, kml, styles
+from fastkml.enums import AltitudeMode
+from pygeoif import LineString, Point
+from rest_framework import permissions, status
+from rest_framework.decorators import api_view, permission_classes
+
+from meshapi.models import Building, Install, Link
+
+KML_CONTENT_TYPE = "application/vnd.google-earth.kml+xml; charset=utf-8"
+DEFAULT_ALTITUDE = 5  # Meters (absolute)
+
+ACTIVE_COLOR = "#F00"
+INACTIVE_COLOR = "#CCC"
+
+CITY_FOLDER_MAP = {
+    "New York": "Manhattan",
+    "Brooklyn": "Brooklyn",
+    "Queens": "Queens",
+    "Bronx": "The Bronx",
+    "Staten Island": "Staten Island",
+    None: "Other",
+}
+
+
+@api_view(["GET"])
+@permission_classes([permissions.AllowAny])
+def map_kml(request):
+    kml_root = kml.KML()
+    ns = "{http://www.opengis.net/kml/2.2}"
+
+    grey_dot = styles.Style(
+        id="grey_dot",
+        styles=[
+            styles.IconStyle(
+                icon=styles.Icon(href="http://maps.google.com/mapfiles/kml/shapes/shaded_dot.png"),
+                hot_spot=styles.HotSpot(x=0.5, y=0.5, xunits=styles.Units.fraction, yunits=styles.Units.fraction),
+            )
+        ],
+    )
+
+    red_dot = styles.Style(
+        id="red_dot",
+        styles=[
+            styles.IconStyle(
+                icon=styles.Icon(href="http://maps.google.com/mapfiles/kml/paddle/red-circle.png"),
+                hot_spot=styles.HotSpot(x=0.5, y=0.5, xunits=styles.Units.fraction, yunits=styles.Units.fraction),
+            )
+        ],
+    )
+
+    red_line = styles.Style(
+        id="red_line",
+        styles=[styles.LineStyle(color="ff0000ff", width=2), styles.PolyStyle(color="00000000")],
+    )
+
+    grey_line = styles.Style(
+        id="grey_line",
+        styles=[styles.LineStyle(color="ffcccccc", width=2), styles.PolyStyle(color="00000000")],
+    )
+
+    kml_document = kml.Document(ns, styles=[grey_dot, red_dot, red_line, grey_line])
+    kml_root.append(kml_document)
+
+    nodes_folder = kml.Folder(name="Nodes")
+    kml_document.append(nodes_folder)
+
+    links_folder = kml.Folder(name="Links")
+    kml_document.append(links_folder)
+
+    folder_map: Dict[str, kml.Folder] = {}
+
+    for city_name, folder_name in CITY_FOLDER_MAP.items():
+        folder_map[city_name] = kml.Folder(name=folder_name)
+        nodes_folder.append(folder_map[city_name])
+
+    for install in Install.objects.filter(
+        ~Q(install_status=Install.InstallStatus.CLOSED)
+        & Q(building__longitude__isnull=False)
+        & Q(building__latitude__isnull=False)
+    ):
+        identifier = install.network_number or install.install_number
+        placemark = kml.Placemark(
+            name=str(identifier),
+            style_url=styles.StyleUrl(
+                url="#red_dot" if install.install_status == Install.InstallStatus.ACTIVE else "#grey_dot"
+            ),
+            kml_geometry=geometry.Point(
+                geometry=Point(
+                    install.building.longitude,
+                    install.building.latitude,
+                    install.building.altitude or DEFAULT_ALTITUDE,
+                ),
+                altitude_mode=AltitudeMode.absolute,
+            ),
+        )
+
+        extended_data = {
+            "name": str(identifier),
+            "roofAccess": str(install.roof_access),
+            "marker-color": ACTIVE_COLOR if install.install_status == Install.InstallStatus.ACTIVE else INACTIVE_COLOR,
+            "id": str(identifier),
+            "install_number": str(install.install_number),
+            "network_number": str(install.network_number),
+            "status": install.install_status,
+            # Leave disabled, notes can leak a lot of information & this endpoint is public
+            # "notes": install.notes,
+        }
+
+        placemark.extended_data = ExtendedData(
+            elements=[Data(name=key, value=val) for key, val in extended_data.items()]
+        )
+        folder = folder_map[install.building.city if install.building.city in folder_map.keys() else None]
+        folder.append(placemark)
+
+    for link in (
+        Link.objects.filter(~Q(status=Link.LinkStatus.DEAD))
+        .annotate(highest_altitude=Greatest("from_building__altitude", "to_building__altitude"))
+        .order_by(F("highest_altitude").asc(nulls_first=True))
+    ):
+        placemark = kml.Placemark(
+            name=f"Links-{link.id}",
+            style_url=styles.StyleUrl(url="#red_line" if link.status == Link.LinkStatus.ACTIVE else "#grey_line"),
+            kml_geometry=geometry.LineString(
+                geometry=LineString(
+                    [
+                        (
+                            link.from_building.longitude,
+                            link.from_building.latitude,
+                            link.from_building.altitude or DEFAULT_ALTITUDE,
+                        ),
+                        (
+                            link.to_building.longitude,
+                            link.to_building.latitude,
+                            link.to_building.altitude or DEFAULT_ALTITUDE,
+                        ),
+                    ]
+                ),
+                altitude_mode=AltitudeMode.absolute,
+                extrude=True,
+            ),
+        )
+
+        from_identifier = link.from_building.primary_nn or link.from_building.installs.first().install_number
+        to_identifier = link.to_building.primary_nn or link.to_building.installs.first().install_number
+
+        extended_data = {
+            "name": f"Links-{link.id}",
+            "stroke": ACTIVE_COLOR if link.status == Link.LinkStatus.ACTIVE else INACTIVE_COLOR,
+            "fill": "#000000",
+            "fill-opacity": "0",
+            "from": str(from_identifier),
+            "to": str(to_identifier),
+            "status": link.status,
+            "type": link.type,
+        }
+
+        placemark.extended_data = ExtendedData(
+            elements=[Data(name=key, value=val) for key, val in extended_data.items()]
+        )
+        links_folder.append(placemark)
+
+    return HttpResponse(
+        kml_root.to_string(),
+        content_type=KML_CONTENT_TYPE,
+        status=status.HTTP_200_OK,
+    )


### PR DESCRIPTION
Adds a kml generator, to reproduce the behavior of the apps-script hosted one. I reverse engineered the apps script logic and checked against the output files, so this should produce KML files that are isomorphic to the originals. Once it's up we can send one to Olivier for verification and feedback

![Screenshot 2024-02-08 at 00 25 48](https://github.com/WillNilges/meshdb/assets/3138937/140608f0-e9e0-4b75-9db5-a9d5eb749fe5)
