### PR TITLE
Fix: admin UI warning is unreadable in dark mode

### DIFF
--- a/src/meshweb/static/admin/admin_ext.css
+++ b/src/meshweb/static/admin/admin_ext.css
@@ -12,6 +12,7 @@
     /*margin-bottom: 5px;*/
     border-radius: 4px;
     border: black 2px solid;
+    color: black;
 }
 
 /* This is an override of the styles at admin/css/login.css in the admin site */


### PR DESCRIPTION
Before
![Screenshot 2024-02-08 at 22 11 37](https://github.com/WillNilges/meshdb/assets/3138937/28061583-4846-4111-8e5b-383571de1d9d)
After
![Screenshot 2024-02-08 at 22 11 18](https://github.com/WillNilges/meshdb/assets/3138937/c9eb2045-f7f5-45af-b62a-025181e5f768)
