### PR TITLE
Fix: Race condition for simultaneous NN assignment requests

### DIFF
--- a/src/meshapi/tests/test_nn.py
+++ b/src/meshapi/tests/test_nn.py
@@ -1,11 +1,15 @@
 import json
+import threading
+import time
+from unittest import mock
 
 from django.conf import os
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import Client, TestCase, TransactionTestCase
 
 from meshapi.models import Building, Install, Member
 
+from ..views import get_next_free_nn
 from .group_helpers import create_groups
 from .sample_data import sample_building, sample_install, sample_member
 
@@ -59,7 +63,7 @@ class TestNN(TestCase):
         self.assertEqual(
             expected_nn,
             resp_nn,
-            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response.status_code}",
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
         )
 
         # Now test to make sure that we get 200 for dupes
@@ -81,7 +85,7 @@ class TestNN(TestCase):
         self.assertEqual(
             expected_nn,
             resp_nn,
-            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response.status_code}",
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
         )
 
     def test_nn_invalid_password(self):
@@ -287,3 +291,163 @@ class TestFindGaps(TestCase):
 
         self.assertIsNotNone(Install.objects.filter(network_number=131)[0].install_number)
         self.assertIsNotNone(Building.objects.filter(primary_nn=131)[0].id)
+
+
+def mocked_slow_nn_lookup():
+    answer = get_next_free_nn()
+    time.sleep(0.5)
+    return answer
+
+
+class TestNNRaceCondition(TransactionTestCase):
+    admin_c = Client()
+
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.admin_c.login(username="admin", password="admin_password")
+
+        # Create sample data
+        member_obj = Member(**sample_member)
+        member_obj.save()
+
+        building = sample_building.copy()
+        building["primary_nn"] = None
+        building_obj1 = Building(**building)
+        building_obj1.save()
+
+        building_obj2 = Building(**building)
+        building_obj2.save()
+
+        inst = sample_install.copy()
+
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+
+        inst["building"] = building_obj1
+        inst["member"] = member_obj
+        inst["network_number"] = None
+
+        install_obj1 = Install(**inst)
+        install_obj1.save()
+
+        inst["building"] = building_obj2
+
+        install_obj2 = Install(**inst)
+        install_obj2.save()
+
+        self.install_number1 = install_obj1.install_number
+        self.install_number2 = install_obj2.install_number
+
+    def test_different_installs_race_condition(self):
+        outputs_dict = {}
+
+        def invoke_nn_form(install_num: int, outputs_dict: dict):
+            # Slow down the call which looks up the NN to force the race condition
+            with mock.patch("meshapi.views.forms.get_next_free_nn", mocked_slow_nn_lookup):
+                result = self.admin_c.post(
+                    "/api/v1/nn-assign/",
+                    {"install_number": install_num, "password": os.environ.get("NN_ASSIGN_PSK")},
+                    content_type="application/json",
+                )
+                outputs_dict[install_num] = result
+
+        t1 = threading.Thread(target=invoke_nn_form, args=(self.install_number1, outputs_dict))
+        time.sleep(0.5)  # Sleep to give the first thread a head start
+        t2 = threading.Thread(target=invoke_nn_form, args=(self.install_number2, outputs_dict))
+
+        t1.start()
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        response1 = outputs_dict[self.install_number1]
+        response2 = outputs_dict[self.install_number2]
+
+        code = 201
+        self.assertEqual(
+            code,
+            response1.status_code,
+            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response1.status_code}",
+        )
+
+        resp_nn = json.loads(response1.content.decode("utf-8"))["network_number"]
+        expected_nn = 101
+        self.assertEqual(
+            expected_nn,
+            resp_nn,
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
+        )
+
+        code = 201
+        self.assertEqual(
+            code,
+            response2.status_code,
+            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response2.status_code}",
+        )
+
+        resp_nn = json.loads(response2.content.decode("utf-8"))["network_number"]
+        expected_nn = 102
+        self.assertEqual(
+            expected_nn,
+            resp_nn,
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
+        )
+
+    def test_same_install_race_condition(self):
+        outputs = []
+
+        def invoke_nn_form(install_num: int, outputs: list):
+            # Slow down the call which looks up the NN to force the race condition
+            with mock.patch("meshapi.views.forms.get_next_free_nn", mocked_slow_nn_lookup):
+                result = self.admin_c.post(
+                    "/api/v1/nn-assign/",
+                    {"install_number": install_num, "password": os.environ.get("NN_ASSIGN_PSK")},
+                    content_type="application/json",
+                )
+                outputs.append(result)
+
+        t1 = threading.Thread(target=invoke_nn_form, args=(self.install_number1, outputs))
+        time.sleep(0.1)  # Sleep to give the first thread a head start
+        t2 = threading.Thread(target=invoke_nn_form, args=(self.install_number1, outputs))
+
+        t1.start()
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        response1 = outputs[0]
+        response2 = outputs[1]
+
+        code = 201
+        self.assertEqual(
+            code,
+            response1.status_code,
+            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response1.status_code}",
+        )
+
+        resp_nn = json.loads(response1.content.decode("utf-8"))["network_number"]
+        expected_nn = 101
+        self.assertEqual(
+            expected_nn,
+            resp_nn,
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
+        )
+
+        code = 200
+        self.assertEqual(
+            code,
+            response2.status_code,
+            f"status code incorrect for test_nn_valid_install_number. Should be {code}, but got {response2.status_code}",
+        )
+
+        resp_nn = json.loads(response2.content.decode("utf-8"))["network_number"]
+        expected_nn = 101
+        self.assertEqual(
+            expected_nn,
+            resp_nn,
+            f"nn incorrect for test_nn_valid_install_number. Should be {expected_nn}, but got {resp_nn}",
+        )

--- a/src/meshapi/tests/test_nn.py
+++ b/src/meshapi/tests/test_nn.py
@@ -354,7 +354,7 @@ class TestNNRaceCondition(TransactionTestCase):
                 outputs_dict[install_num] = result
 
         t1 = threading.Thread(target=invoke_nn_form, args=(self.install_number1, outputs_dict))
-        time.sleep(0.5)  # Sleep to give the first thread a head start
+        time.sleep(0.1)  # Sleep to give the first thread a head start
         t2 = threading.Thread(target=invoke_nn_form, args=(self.install_number2, outputs_dict))
 
         t1.start()

--- a/src/meshapi/util/django_pglocks.py
+++ b/src/meshapi/util/django_pglocks.py
@@ -11,7 +11,6 @@ from zlib import crc32
 
 @contextmanager
 def advisory_lock(lock_id, shared=False, wait=True, using=None):
-
     import six
     from django.db import DEFAULT_DB_ALIAS, connections, transaction
 

--- a/src/meshapi/util/django_pglocks.py
+++ b/src/meshapi/util/django_pglocks.py
@@ -1,0 +1,97 @@
+# Copied from https://github.com/Xof/django-pglocks/blob/master/django_pglocks/__init__.py
+# we don't just pip install, since this package is incompatible with 3.12 due to its outdated
+# build system, and though a patch has been waiting in PR for 3 years:
+# https://github.com/Xof/django-pglocks/pull/27
+# it does not appear the repo is maintained anymore. This code is so simple it's unlikely we'll
+# need a patch from upstream anyhow...
+
+from contextlib import contextmanager
+from zlib import crc32
+
+
+@contextmanager
+def advisory_lock(lock_id, shared=False, wait=True, using=None):
+
+    import six
+    from django.db import DEFAULT_DB_ALIAS, connections, transaction
+
+    if using is None:
+        using = DEFAULT_DB_ALIAS
+
+    # Assemble the function name based on the options.
+
+    function_name = "pg_"
+
+    if not wait:
+        function_name += "try_"
+
+    function_name += "advisory_lock"
+
+    if shared:
+        function_name += "_shared"
+
+    release_function_name = "pg_advisory_unlock"
+    if shared:
+        release_function_name += "_shared"
+
+    # Format up the parameters.
+
+    tuple_format = False
+
+    if isinstance(
+        lock_id,
+        (
+            list,
+            tuple,
+        ),
+    ):
+        if len(lock_id) != 2:
+            raise ValueError("Tuples and lists as lock IDs must have exactly two entries.")
+
+        if not isinstance(lock_id[0], six.integer_types) or not isinstance(lock_id[1], six.integer_types):
+            raise ValueError("Both members of a tuple/list lock ID must be integers")
+
+        tuple_format = True
+    elif isinstance(lock_id, six.string_types):
+        # Generates an id within postgres integer range (-2^31 to 2^31 - 1).
+        # crc32 generates an unsigned integer in Py3, we convert it into
+        # a signed integer using 2's complement (this is a noop in Py2)
+        pos = crc32(lock_id.encode("utf-8"))
+        lock_id = (2**31 - 1) & pos
+        if pos & 2**31:
+            lock_id -= 2**31
+    elif not isinstance(lock_id, six.integer_types):
+        raise ValueError("Cannot use %s as a lock id" % lock_id)
+
+    if tuple_format:
+        base = "SELECT %s(%d, %d)"
+        params = (
+            lock_id[0],
+            lock_id[1],
+        )
+    else:
+        base = "SELECT %s(%d)"
+        params = (lock_id,)
+
+    acquire_params = (function_name,) + params
+
+    command = base % acquire_params
+    cursor = connections[using].cursor()
+
+    cursor.execute(command)
+
+    if not wait:
+        acquired = cursor.fetchone()[0]
+    else:
+        acquired = True
+
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            release_params = (release_function_name,) + params
+
+            command = base % release_params
+            cursor.execute(command)
+
+        cursor.close()

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -267,7 +267,10 @@ def network_number_assignment(request):
     if nn_building.primary_nn is not None:
         nn_install.network_number = nn_building.primary_nn
     else:
-        free_nn = get_next_free_nn()
+        try:
+            free_nn = get_next_free_nn()
+        except ValueError as exception:
+            return Response({"detail": f"NN Request failed. {exception}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         # Set the next free NN on both the install and the Building
         nn_install.network_number = free_nn

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -191,7 +191,6 @@ def join_form(request):
 
 
 def get_next_free_nn() -> int:
-
     defined_nns = set(
         Install.objects.exclude(install_status=Install.InstallStatus.REQUEST_RECEIVED, network_number__isnull=True)
         .order_by("install_number")

--- a/src/meshapi/views/forms.py
+++ b/src/meshapi/views/forms.py
@@ -211,10 +211,10 @@ def acquire_lock_for_all_installs():
     # This code may look useless but is extremely important. Here we use select_for_update()
     # to acquire locks on every single row in the Install table. This is a bit hacky, but based
     # on how our NN assignment logic works, we kind of need it. There's nothing else we can lock
-    # to prevent the same NN from being assigned to multiple installs when requested concurrently
-    # we order by the table's primary key to prevent deadlocks due to out-of-order locking, and we
+    # to prevent the same NN from being assigned to multiple installs when requested concurrently.
+    # We order by the table's primary key to prevent deadlocks due to out-of-order locking, and we
     # call len() to make sure the queryset is traversed (which is what actually acquires the lock)
-    # this must be called in the context of a transaction.atomic block, which also automatically
+    # This must be called in the context of a transaction.atomic block, which also automatically
     # handles the release of the lock for us
     lock_qs = Install.objects.select_for_update().all().order_by("install_number")
     len(lock_qs)


### PR DESCRIPTION
A race condition existed when two NN assignment requests are received concurrently, where both requests would get the same NN. This was probably never gonna happen, but once I wrote a test case confirming it was possible I had to fix it :)