### PR TITLE
Map endpoint audit fixes

### DIFF
--- a/src/meshapi/serializers/map.py
+++ b/src/meshapi/serializers/map.py
@@ -88,6 +88,8 @@ class MapDataInstallSerializer(serializers.ModelSerializer):
             return "Powered Off"
         elif install.install_status == Install.InstallStatus.CLOSED:
             return "Abandoned"
+        elif install.install_status == Install.InstallStatus.NN_REASSIGNED:
+            return "NN Assigned"
 
         return install.install_status
 

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -143,7 +143,7 @@ class TestViewsGetUnauthenticated(TestCase):
         installs.append(
             Install(
                 install_number=245,
-                install_status=Install.InstallStatus.NN_ASSIGNED,
+                install_status=Install.InstallStatus.NN_REASSIGNED,
                 request_date=datetime.date(2024, 1, 27),
                 roof_access=True,
                 building=buildings[-1],

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -74,11 +74,13 @@ class TestViewsGetUnauthenticated(TestCase):
                 longitude=-73.987881,
                 altitude=27,
                 node_name="Brian",
+                primary_nn=3,
             )
         )
         installs.append(
             Install(
                 install_number=3,
+                network_number=3,
                 install_status=Install.InstallStatus.ACTIVE,
                 request_date=datetime.date(2015, 3, 15),
                 install_date=datetime.date(2014, 10, 14),
@@ -122,6 +124,48 @@ class TestViewsGetUnauthenticated(TestCase):
             Install(
                 install_number=14956,
                 install_status=Install.InstallStatus.PENDING,
+                request_date=datetime.date(2024, 1, 27),
+                roof_access=True,
+                building=buildings[-1],
+                member=member,
+            )
+        )
+
+        buildings.append(
+            Building(
+                building_status=Building.BuildingStatus.ACTIVE,
+                address_truth_sources="",
+                latitude=40.6962265,
+                longitude=-73.9917741,
+                altitude=66,
+            )
+        )
+        installs.append(
+            Install(
+                install_number=245,
+                install_status=Install.InstallStatus.NN_ASSIGNED,
+                request_date=datetime.date(2024, 1, 27),
+                roof_access=True,
+                building=buildings[-1],
+                member=member,
+            )
+        )
+
+        buildings.append(
+            Building(
+                building_status=Building.BuildingStatus.ACTIVE,
+                address_truth_sources="",
+                latitude=40.6962265,
+                longitude=-73.9917741,
+                altitude=66,
+                primary_nn=567,
+            )
+        )
+        installs.append(
+            Install(
+                install_number=15657,
+                network_number=567,
+                install_status=Install.InstallStatus.ACTIVE,
                 request_date=datetime.date(2024, 1, 27),
                 roof_access=True,
                 building=buildings[-1],
@@ -181,8 +225,24 @@ class TestViewsGetUnauthenticated(TestCase):
                     "panoramas": [],
                 },
                 {
+                    "id": 567,
+                    "status": "NN Assigned",
+                    "coordinates": [-73.9917741, 40.6962265, 66.0],
+                    "requestDate": 1706313600000,
+                    "roofAccess": True,
+                    "panoramas": [],
+                },
+                {
                     "id": 14956,
                     "status": "Interested",
+                    "coordinates": [-73.9917741, 40.6962265, 66.0],
+                    "requestDate": 1706313600000,
+                    "roofAccess": True,
+                    "panoramas": [],
+                },
+                {
+                    "id": 15657,
+                    "status": "Installed",
                     "coordinates": [-73.9917741, 40.6962265, 66.0],
                     "requestDate": 1706313600000,
                     "roofAccess": True,

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -292,14 +292,6 @@ class TestViewsGetUnauthenticated(TestCase):
                     "installDate": 1616284800000,
                 },
                 {
-                    "nodeId": 227,
-                    "radius": 0.75,
-                    "azimuth": 300,
-                    "width": 90,
-                    "status": "abandoned",
-                    "device": "SN1Sector2",
-                },
-                {
                     "nodeId": 1126,
                     "radius": 0.3,
                     "azimuth": 0,

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -15,7 +15,7 @@ class MapDataInstallList(generics.ListAPIView):
 
         excluded_statuses = {
             Install.InstallStatus.CLOSED,
-            Install.InstallStatus.NN_ASSIGNED,
+            Install.InstallStatus.NN_REASSIGNED,
         }
 
         queryset = Install.objects.filter(~Q(install_status__in=excluded_statuses))

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -13,22 +13,37 @@ class MapDataInstallList(generics.ListAPIView):
     def get_queryset(self):
         all_installs = []
 
-        queryset = Install.objects.filter(~Q(install_status__in=[Install.InstallStatus.CLOSED]))
+        queryset = Install.objects.filter(
+            ~Q(
+                install_status__in=[
+                    Install.InstallStatus.CLOSED,
+                    Install.InstallStatus.NN_ASSIGNED,
+                ]
+            )
+        )
 
         for install in queryset:
             all_installs.append(install)
 
+        # We need to make sure there is an entry on the map for every NN, and since we excluded the
+        # NN assigned rows in the query above, we need to go through the building objects and
+        # include the nns we haven't already covered via install num
+        covered_nns = {
+            install.network_number for install in all_installs if install.install_number == install.network_number
+        }
         for building in Building.objects.filter(primary_nn__isnull=False):
-            representative_install = building.installs.all()[0]
-            all_installs.append(
-                Install(
-                    install_number=building.primary_nn,
-                    install_status=Install.InstallStatus.NN_REASSIGNED,
-                    building=building,
-                    request_date=representative_install.request_date,
-                    roof_access=representative_install.roof_access,
-                ),
-            )
+            if building.primary_nn not in covered_nns:
+                representative_install = building.installs.all()[0]
+                all_installs.append(
+                    Install(
+                        install_number=building.primary_nn,
+                        install_status=Install.InstallStatus.NN_REASSIGNED,
+                        building=building,
+                        request_date=representative_install.request_date,
+                        roof_access=representative_install.roof_access,
+                    ),
+                )
+                covered_nns.add(building.primary_nn)
 
         all_installs.sort(key=lambda i: i.install_number)
         return all_installs

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -45,4 +45,4 @@ class MapDataSectorlList(generics.ListAPIView):
     permission_classes = [permissions.AllowAny]
     serializer_class = MapDataSectorSerializer
     pagination_class = None
-    queryset = Sector.objects.all()
+    queryset = Sector.objects.filter(~Q(status__in=[Sector.SectorStatus.ABANDONED]))


### PR DESCRIPTION
Audited the map endpoint code and compared against the node-db version: https://github.com/nycmeshnet/node-db/blob/master/src/spreadsheet.js#L119

Found a few discrepencies:
 - Nodes from re-assigned NNs are not being handled correctly
 - Abandoned sectors should not be included in the output JSON
 
This PR fixes these issues and closes #164 