### PR TITLE
Adjust link serialization logic to match current map display

### DIFF
--- a/src/meshapi/urls.py
+++ b/src/meshapi/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path("query/install/", views.QueryInstall.as_view(), name="meshapi-v1-query-install"),
     path("mapdata/installs/", views.MapDataInstallList.as_view(), name="meshapi-v1-map-data-installs"),
     path("mapdata/links/", views.MapDataLinkList.as_view(), name="meshapi-v1-map-data-links"),
-    path("mapdata/sectors/", views.MapDataSectorlList.as_view(), name="meshapi-v1-map-data-sectors"),
+    path("mapdata/sectors/", views.MapDataSectorList.as_view(), name="meshapi-v1-map-data-sectors"),
     path("geography/whole-mesh.kml", views.map_kml, name="meshapi-v1-geography-whole-mesh-kml"),
 ]
 


### PR DESCRIPTION
Adjust the serialization logic so that we line up nearly perfectly with the current map display (and a few small refactors). There are some small remaining discrepancies some are due to bad spreadsheet data (that we validate and correct at import time, resulting in nodes changing slightly), and AP/multi-install display (captured in #192) but 95% of the map looks identical.

Here's an example. There's an abandoned node (NN558) in the spreadsheet data that shows up on the map incorrectly, we've filtered it out

Map based on our data:
<img width="1093" alt="Screenshot 2024-02-15 at 00 12 42" src="https://github.com/WillNilges/meshdb/assets/3138937/79a555ef-4c78-490f-9de9-c955bc6fcbda">

Live map
<img width="1067" alt="Screenshot 2024-02-15 at 00 13 52" src="https://github.com/WillNilges/meshdb/assets/3138937/ac9265d4-c09c-491b-9b8e-b34fd0d5b7d3">
