### PR TITLE
Add the ability for clients to limit recursion depth to reduce response sizes

### DIFF
--- a/src/meshapi/tests/test_recursive_views.py
+++ b/src/meshapi/tests/test_recursive_views.py
@@ -499,6 +499,22 @@ class TestMonsterQuery(TestCase):
         self.maxDiff = None
         self.c.login(username="admin", password="admin_password")
 
+        response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=-2")
+        code = 400
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=blahhh")
+        code = 400
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
         response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=0")
 
         code = 200

--- a/src/meshapi/tests/test_recursive_views.py
+++ b/src/meshapi/tests/test_recursive_views.py
@@ -353,6 +353,435 @@ class TestMonsterQuery(TestCase):
         self.maxDiff = None
         self.c.login(username="admin", password="admin_password")
 
+        for i in [None, 3, 4, 5]:
+            if i is None:
+                response = self.c.get(f"/api/v1/links/1/")
+            else:
+                response = self.c.get(f"/api/v1/links/1/?max_recursion_depth={i}")
+
+            code = 200
+            self.assertEqual(
+                code,
+                response.status_code,
+                f"status code incorrect. Should be {code}, but got {response.status_code}",
+            )
+
+            response_obj = json.loads(response.content)
+            self.assertEqual(response_obj["status"], "Active")
+            self.assertEqual(
+                response_obj["from_building"],
+                {
+                    "id": 1,
+                    "installs": [
+                        {
+                            "install_number": 2000,
+                            "member": {
+                                "id": 1,
+                                "name": "John Smith",
+                                "primary_email_address": "john.smith@example.com",
+                                "stripe_email_address": None,
+                                "additional_email_addresses": [],
+                                "all_email_addresses": ["john.smith@example.com"],
+                                "phone_number": "555-555-5555",
+                                "slack_handle": "@jsmith",
+                                "invalid": False,
+                                "contact_notes": None,
+                            },
+                            "network_number": 2000,
+                            "install_status": "Active",
+                            "ticket_id": 69,
+                            "request_date": "2022-02-27",
+                            "install_date": "2022-03-01",
+                            "abandon_date": "9999-01-01",
+                            "unit": "3",
+                            "roof_access": True,
+                            "referral": None,
+                            "notes": "Referral: Read about it on the internet",
+                            "diy": None,
+                        }
+                    ],
+                    "sectors": [
+                        {
+                            "id": 1,
+                            "name": "Vernon",
+                            "radius": 0.3,
+                            "azimuth": 0,
+                            "width": 120,
+                            "status": "Active",
+                            "install_date": None,
+                            "abandon_date": None,
+                            "device_name": "LAP-120",
+                            "ssid": None,
+                            "notes": None,
+                        }
+                    ],
+                    "bin": 8888,
+                    "building_status": "Active",
+                    "street_address": "3333 Chom St",
+                    "city": "Brooklyn",
+                    "state": "NY",
+                    "zip_code": "11111",
+                    "invalid": False,
+                    "address_truth_sources": "['NYCPlanningLabs']",
+                    "latitude": 0.0,
+                    "longitude": 0.0,
+                    "altitude": 0.0,
+                    "primary_nn": None,
+                    "node_name": None,
+                    "notes": None,
+                },
+            )
+            self.assertEqual(
+                response_obj["to_building"],
+                {
+                    "id": 2,
+                    "installs": [
+                        {
+                            "install_number": 2001,
+                            "member": {
+                                "id": 2,
+                                "name": "Donald Smith",
+                                "primary_email_address": "john.smith@example.com",
+                                "stripe_email_address": None,
+                                "additional_email_addresses": [],
+                                "all_email_addresses": ["john.smith@example.com"],
+                                "phone_number": "555-555-5555",
+                                "slack_handle": "@jsmith",
+                                "invalid": False,
+                                "contact_notes": None,
+                            },
+                            "network_number": 2000,
+                            "install_status": "Active",
+                            "ticket_id": 69,
+                            "request_date": "2022-02-27",
+                            "install_date": "2022-03-01",
+                            "abandon_date": "9999-01-01",
+                            "unit": "3",
+                            "roof_access": True,
+                            "referral": None,
+                            "notes": "Referral: Read about it on the internet",
+                            "diy": None,
+                        }
+                    ],
+                    "sectors": [
+                        {
+                            "id": 2,
+                            "name": "Vernon",
+                            "radius": 0.3,
+                            "azimuth": 0,
+                            "width": 120,
+                            "status": "Active",
+                            "install_date": None,
+                            "abandon_date": None,
+                            "device_name": "LAP-120",
+                            "ssid": None,
+                            "notes": None,
+                        }
+                    ],
+                    "bin": 8888,
+                    "building_status": "Active",
+                    "street_address": "3333 Chom St",
+                    "city": "Brooklyn",
+                    "state": "NY",
+                    "zip_code": "11111",
+                    "invalid": False,
+                    "address_truth_sources": "['NYCPlanningLabs']",
+                    "latitude": 0.0,
+                    "longitude": 0.0,
+                    "altitude": 0.0,
+                    "primary_nn": None,
+                    "node_name": None,
+                    "notes": None,
+                },
+            )
+
+    def test_views_get_link_recursion_limits(self):
+        self.maxDiff = None
+        self.c.login(username="admin", password="admin_password")
+
+        response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=0")
+
+        code = 200
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+        self.assertEqual(response_obj["status"], "Active")
+        self.assertEqual(
+            response_obj["from_building"],
+            {
+                "id": 1,
+            },
+        )
+        self.assertEqual(
+            response_obj["to_building"],
+            {
+                "id": 2,
+            },
+        )
+
+        response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=1")
+
+        code = 200
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+        self.assertEqual(response_obj["status"], "Active")
+        self.assertEqual(
+            response_obj["from_building"],
+            {
+                "id": 1,
+                "installs": [
+                    {
+                        "install_number": 2000,
+                    }
+                ],
+                "sectors": [
+                    {
+                        "id": 1,
+                    }
+                ],
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+        self.assertEqual(
+            response_obj["to_building"],
+            {
+                "id": 2,
+                "installs": [
+                    {
+                        "install_number": 2001,
+                    }
+                ],
+                "sectors": [
+                    {
+                        "id": 2,
+                    }
+                ],
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+
+        response = self.c.get(f"/api/v1/links/1/?max_recursion_depth=2")
+
+        code = 200
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"status code incorrect. Should be {code}, but got {response.status_code}",
+        )
+
+        response_obj = json.loads(response.content)
+        self.assertEqual(response_obj["status"], "Active")
+        self.assertEqual(
+            response_obj["from_building"],
+            {
+                "id": 1,
+                "installs": [
+                    {
+                        "install_number": 2000,
+                        "member": {
+                            "id": 1,
+                        },
+                        "network_number": 2000,
+                        "install_status": "Active",
+                        "ticket_id": 69,
+                        "request_date": "2022-02-27",
+                        "install_date": "2022-03-01",
+                        "abandon_date": "9999-01-01",
+                        "unit": "3",
+                        "roof_access": True,
+                        "referral": None,
+                        "notes": "Referral: Read about it on the internet",
+                        "diy": None,
+                    }
+                ],
+                "sectors": [
+                    {
+                        "id": 1,
+                        "name": "Vernon",
+                        "radius": 0.3,
+                        "azimuth": 0,
+                        "width": 120,
+                        "status": "Active",
+                        "install_date": None,
+                        "abandon_date": None,
+                        "device_name": "LAP-120",
+                        "ssid": None,
+                        "notes": None,
+                    }
+                ],
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+        self.assertEqual(
+            response_obj["to_building"],
+            {
+                "id": 2,
+                "installs": [
+                    {
+                        "install_number": 2001,
+                        "member": {
+                            "id": 2,
+                        },
+                        "network_number": 2000,
+                        "install_status": "Active",
+                        "ticket_id": 69,
+                        "request_date": "2022-02-27",
+                        "install_date": "2022-03-01",
+                        "abandon_date": "9999-01-01",
+                        "unit": "3",
+                        "roof_access": True,
+                        "referral": None,
+                        "notes": "Referral: Read about it on the internet",
+                        "diy": None,
+                    }
+                ],
+                "sectors": [
+                    {
+                        "id": 2,
+                        "name": "Vernon",
+                        "radius": 0.3,
+                        "azimuth": 0,
+                        "width": 120,
+                        "status": "Active",
+                        "install_date": None,
+                        "abandon_date": None,
+                        "device_name": "LAP-120",
+                        "ssid": None,
+                        "notes": None,
+                    }
+                ],
+                "bin": 8888,
+                "building_status": "Active",
+                "street_address": "3333 Chom St",
+                "city": "Brooklyn",
+                "state": "NY",
+                "zip_code": "11111",
+                "invalid": False,
+                "address_truth_sources": "['NYCPlanningLabs']",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "altitude": 0.0,
+                "primary_nn": None,
+                "node_name": None,
+                "notes": None,
+            },
+        )
+
+
+class TestMonsterQuery(TestCase):
+    c = Client()
+
+    def setUp(self):
+        # Create sample data
+        member_obj_1, building_obj_1, install_obj_1 = setup_objects()
+
+        member_obj_2 = Member(id=2, **sample_member)
+        member_obj_2.name = "Donald Smith"
+        member_obj_2.save()
+
+        building = sample_building.copy()
+        building["primary_nn"] = None
+        building_obj_2 = Building(id=2, **building)
+        building_obj_2.save()
+        inst = sample_install.copy()
+
+        if inst["abandon_date"] == "":
+            inst["abandon_date"] = None
+
+        inst["building"] = building_obj_2
+        inst["member"] = member_obj_2
+        inst["install_number"] = 2001
+        install_obj_2 = Install(**inst)
+        install_obj_2.save()
+
+        sector_1 = Sector(
+            id=1,
+            name="Vernon",
+            device_name="LAP-120",
+            building=building_obj_1,
+            status="Active",
+            azimuth=0,
+            width=120,
+            radius=0.3,
+        )
+        sector_1.save()
+
+        sector_2 = Sector(
+            id=2,
+            name="Vernon",
+            device_name="LAP-120",
+            building=building_obj_2,
+            status="Active",
+            azimuth=0,
+            width=120,
+            radius=0.3,
+        )
+        sector_2.save()
+
+        link = Link(
+            id=1,
+            from_building=building_obj_1,
+            to_building=building_obj_2,
+            status=Link.LinkStatus.ACTIVE,
+        )
+        link.save()
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+
+    def test_views_get_link(self):
+        self.maxDiff = None
+        self.c.login(username="admin", password="admin_password")
+
         response = self.c.get(f"/api/v1/links/1/")
 
         code = 200

--- a/src/meshapi_hooks/hooks.py
+++ b/src/meshapi_hooks/hooks.py
@@ -9,16 +9,17 @@ from meshapi.serializers import RecursiveSerializer
 
 class MockRequestForWebhookSerializer:
     """
-    An object which defines a .user attribute that we can pass to our serializers in place of an
-    actual DRF Request object. These are complex to construct, and since we only need to access
-    the user attribute inside the serializer, this mock performs just fine.
+    An object which defines .user and .query_params attributes that we can pass to our serializers
+    in place of an actual DRF Request object. These are complex to construct, and since we only need
+    to access these attributes inside the serializer, this mock performs just fine.
     """
 
     def __init__(self, user: User):
         self.user = user
+        self.query_params = {}
 
     def __getattribute__(self, item):
-        if item == "user":
+        if item in ["user", "query_params"]:
             return super().__getattribute__(item)
         else:
             raise AttributeError(


### PR DESCRIPTION
The chonker of a response object introduced in #199 made me think that some clients are going to want the ability to limit the depth of the recursion in the object they receive, this PR adds a `?max_recursion_depth` parameter available on any of the endpoints that are backed by `RecursiveSerializer` which can be optionally used to limit the depth if the caller is only interested in shallower data fields