### PR TITLE
Remove unused /user endpoints to reduce confusion

### DIFF
--- a/src/meshapi/serializers/model_api.py
+++ b/src/meshapi/serializers/model_api.py
@@ -11,12 +11,6 @@ from meshapi.models import Building, Install, Link, Member, Sector
 from meshapi.permissions import check_has_model_view_permission
 
 
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = "__all__"
-
-
 class RecursiveSerializer(serializers.ModelSerializer):
     """
     A serializer which follows foreign-key relationships when serializing, taking care to avoid

--- a/src/meshapi/urls.py
+++ b/src/meshapi/urls.py
@@ -6,8 +6,6 @@ from meshapi import views
 urlpatterns = [
     path("", views.api_root),
     path("auth/", include("rest_framework.urls")),
-    path("users/", views.UserList.as_view(), name="meshapi-v1-user-list"),
-    path("users/<int:pk>/", views.UserDetail.as_view(), name="meshapi-v1-user-detail"),
     path("buildings/", views.BuildingList.as_view(), name="meshapi-v1-building-list"),
     path("buildings/<int:pk>/", views.BuildingDetail.as_view(), name="meshapi-v1-building-detail"),
     path("members/", views.MemberList.as_view(), name="meshapi-v1-member-list"),

--- a/src/meshapi/views/model_api.py
+++ b/src/meshapi/views/model_api.py
@@ -11,7 +11,6 @@ from meshapi.serializers import (
     LinkSerializer,
     MemberSerializer,
     SectorSerializer,
-    UserSerializer,
 )
 
 
@@ -20,16 +19,6 @@ from meshapi.serializers import (
 @permission_classes([permissions.AllowAny])
 def api_root(request, format=None):
     return Response("We're meshin'.")
-
-
-class UserList(generics.ListAPIView):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-
-
-class UserDetail(generics.RetrieveAPIView):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
 
 
 class BuildingList(generics.ListCreateAPIView):

--- a/src/meshdb/urls.py
+++ b/src/meshdb/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
Remove user endpoints, these are not needed and just serve to confuse our API consumers, given the close naming but totally separate purpose to the `Member` table