### PR TITLE
Update list views to avoid blank entries, fix TabularInline Install view, and other bugfixes

### DIFF
--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -9,12 +9,13 @@ admin.site.index_title = "Welcome to MeshDB Admin Portal"
 
 # Register your models here.
 
+
 class InstallInline(admin.TabularInline):
     model = Install
     extra = 0  # Number of empty forms to display
     show_change_link = True
-    fields = ["install_status", "network_number", "member", "unit"] 
-    readonly_fields = fields 
+    fields = ["install_status", "network_number", "member", "unit"]
+    readonly_fields = fields
     can_delete = False
 
     def has_add_permission(self, request, obj):

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -163,6 +163,7 @@ class MemberAdmin(admin.ModelAdmin):
     ]
     inlines = [InstallInline]
     list_display = [
+        "__str__",
         "name",
         "primary_email_address",
         "phone_number",
@@ -268,7 +269,7 @@ class LinkAdmin(admin.ModelAdmin):
         "from_building__icontains",
         "to_building__icontains",
     ]
-    list_display = ["id", "from_building", "to_building"]
+    list_display = ["__str__", "from_building", "to_building"]
     list_filter = ["status", "type"]
 
 

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -9,10 +9,16 @@ admin.site.index_title = "Welcome to MeshDB Admin Portal"
 
 # Register your models here.
 
-
 class InstallInline(admin.TabularInline):
     model = Install
-    extra = 1  # Number of empty forms to display
+    extra = 0  # Number of empty forms to display
+    show_change_link = True
+    fields = ["install_status", "network_number", "member", "unit"] 
+    readonly_fields = fields 
+    can_delete = False
+
+    def has_add_permission(self, request, obj):
+        return False
 
 
 class BuildingAdminForm(forms.ModelForm):
@@ -74,7 +80,7 @@ class BuildingAdmin(admin.ModelAdmin):
         "installs__install_number__iexact",
         # Search by Member info
         "installs__member__name__icontains",
-        "installs__member__email_address__icontains",
+        "installs__member__primary_email_address__icontains",
         "installs__member__phone_number__iexact",
         "installs__member__slack_handle__iexact",
     ]
@@ -148,7 +154,7 @@ class MemberAdmin(admin.ModelAdmin):
     search_fields = [
         # Search by name
         "name__icontains",
-        "email_address__icontains",
+        "primary_email_address__icontains",
         "phone_number__icontains",
         "slack_handle__icontains",
         # Search by building details

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -201,7 +201,7 @@ class MemberAdmin(admin.ModelAdmin):
         "name__icontains",
         "primary_email_address__icontains",
         "stripe_email_address__icontains",
-        "secondary_email_addresses__icontains",
+        "additional_email_addresses__icontains",
         "phone_number__icontains",
         "slack_handle__icontains",
         # Search by building details
@@ -319,8 +319,12 @@ class LinkAdminForm(forms.ModelForm):
 class LinkAdmin(admin.ModelAdmin):
     form = LinkAdminForm
     search_fields = [
-        "from_building__icontains",
-        "to_building__icontains",
+        "from_building__node_name__icontains",
+        "to_building__node_name__icontains",
+        "from_building__street_address__icontains",
+        "to_building__street_address__icontains",
+        "from_building__primary_nn__iexact",
+        "to_building__primary_nn__iexact",
     ]
     list_display = ["__str__", "status", "from_building", "to_building", "description"]
     list_filter = ["status", "type"]

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -23,7 +23,7 @@ class InstallInline(admin.TabularInline):
 
     class Media:
         css = {
-            'all': ('admin/admin.css',),
+            "all": ("admin/admin.css",),
         }
 
 

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -24,7 +24,7 @@ class InstallInline(admin.TabularInline):
 
     class Media:
         css = {
-            "all": ("admin/admin.css",),
+            "all": ("admin/install_tabular.css",),
         }
 
 
@@ -202,7 +202,7 @@ class InstallAdmin(admin.ModelAdmin):
         "install_date",
         "abandon_date",
     ]
-    list_display = ["install_number", "network_number", "member", "building", "unit"]
+    list_display = ["__str__", "network_number", "member", "building", "unit"]
     search_fields = [
         # Install number
         "install_number__iexact",

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -21,6 +21,11 @@ class InstallInline(admin.TabularInline):
     def has_add_permission(self, request, obj):
         return False
 
+    class Media:
+        css = {
+            'all': ('admin/admin.css',),
+        }
+
 
 class BuildingAdminForm(forms.ModelForm):
     class Meta:

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -46,6 +46,7 @@ class FromBuildingInline(admin.TabularInline):
             "all": ("admin/install_tabular.css",),
         }
 
+
 # This controls the list of installs reverse FK'd to Buildings and Members
 class ToBuildingInline(admin.TabularInline):
     model = Link

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -27,6 +27,45 @@ class InstallInline(admin.TabularInline):
         }
 
 
+# This controls the list of installs reverse FK'd to Buildings and Members
+class FromBuildingInline(admin.TabularInline):
+    model = Link
+    extra = 0
+    # show_change_link = True
+    fields = ["status", "to_building", "description"]
+    readonly_fields = fields
+    can_delete = False
+    template = "admin/install_tabular.html"
+    fk_name = "from_building"
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    class Media:
+        css = {
+            "all": ("admin/install_tabular.css",),
+        }
+
+# This controls the list of installs reverse FK'd to Buildings and Members
+class ToBuildingInline(admin.TabularInline):
+    model = Link
+    extra = 0
+    # show_change_link = True
+    fields = ["status", "from_building", "description"]
+    readonly_fields = fields
+    can_delete = False
+    template = "admin/install_tabular.html"
+    fk_name = "to_building"
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    class Media:
+        css = {
+            "all": ("admin/install_tabular.css",),
+        }
+
+
 class BuildingAdminForm(forms.ModelForm):
     class Meta:
         model = Building
@@ -89,7 +128,7 @@ class BuildingAdmin(admin.ModelAdmin):
         "installs__member__phone_number__iexact",
         "installs__member__slack_handle__iexact",
     ]
-    inlines = [InstallInline]
+    inlines = [InstallInline, ToBuildingInline, FromBuildingInline]
     list_filter = [
         "building_status",
         ("primary_nn", admin.EmptyFieldListFilter),
@@ -282,7 +321,7 @@ class LinkAdmin(admin.ModelAdmin):
         "from_building__icontains",
         "to_building__icontains",
     ]
-    list_display = ["__str__", "from_building", "to_building"]
+    list_display = ["__str__", "status", "from_building", "to_building", "description"]
     list_filter = ["status", "type"]
 
 

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -12,7 +12,7 @@ admin.site.index_title = "Welcome to MeshDB Admin Portal"
 
 class InstallInline(admin.TabularInline):
     model = Install
-    extra = 0  
+    extra = 0
     # show_change_link = True
     fields = ["install_status", "network_number", "member", "unit"]
     readonly_fields = fields

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -12,11 +12,12 @@ admin.site.index_title = "Welcome to MeshDB Admin Portal"
 
 class InstallInline(admin.TabularInline):
     model = Install
-    extra = 0  # Number of empty forms to display
-    show_change_link = True
+    extra = 0  
+    # show_change_link = True
     fields = ["install_status", "network_number", "member", "unit"]
     readonly_fields = fields
     can_delete = False
+    template = "admin/install_tabular.html"
 
     def has_add_permission(self, request, obj):
         return False

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -7,9 +7,8 @@ admin.site.site_header = "MeshDB Admin"
 admin.site.site_title = "MeshDB Admin Portal"
 admin.site.index_title = "Welcome to MeshDB Admin Portal"
 
-# Register your models here.
 
-
+# This controls the list of installs reverse FK'd to Buildings and Members
 class InstallInline(admin.TabularInline):
     model = Install
     extra = 0
@@ -38,7 +37,6 @@ class BuildingAdminForm(forms.ModelForm):
             "state": forms.TextInput(),
             "zip_code": forms.NumberInput(),
             "node_name": forms.TextInput(),
-            "street_address": forms.TextInput(),
         }
 
 
@@ -162,6 +160,8 @@ class MemberAdmin(admin.ModelAdmin):
         # Search by name
         "name__icontains",
         "primary_email_address__icontains",
+        "stripe_email_address__icontains",
+        "secondary_email_addresses__icontains",
         "phone_number__icontains",
         "slack_handle__icontains",
         # Search by building details
@@ -179,6 +179,7 @@ class MemberAdmin(admin.ModelAdmin):
         "__str__",
         "name",
         "primary_email_address",
+        "stripe_email_address",
         "phone_number",
     ]
 
@@ -215,7 +216,7 @@ class InstallAdmin(admin.ModelAdmin):
         "building__bin__iexact",
         # Search by member details
         "member__name__icontains",
-        "member__email_address__icontains",
+        "member__primary_email_address__icontains",
         "member__phone_number__iexact",
         "member__slack_handle__iexact",
     ]
@@ -227,7 +228,6 @@ class InstallAdmin(admin.ModelAdmin):
                 "fields": [
                     "member",
                     "install_status",
-                    # "install_number",
                     "ticket_id",
                     "network_number",
                 ]

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -202,7 +202,7 @@ class InstallAdmin(admin.ModelAdmin):
         "install_date",
         "abandon_date",
     ]
-    list_display = ["__str__", "network_number", "member", "building", "unit"]
+    list_display = ["__str__", "install_status", "network_number", "member", "building", "unit"]
     search_fields = [
         # Install number
         "install_number__iexact",

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -289,7 +289,7 @@ class SectorAdmin(admin.ModelAdmin):
     form = SectorAdminForm
     search_fields = ["name__icontains", "device_name__icontains", "ssid__icontains"]
     list_display = [
-        "id",
+        "__str__",
         "ssid",
         "name",
         "device_name",

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -85,7 +85,7 @@ class BuildingAdmin(admin.ModelAdmin):
         ("node_name", admin.EmptyFieldListFilter),
         BoroughFilter,
     ]
-    list_display = ["street_address", "node_name", "primary_nn"]
+    list_display = ["__str__", "street_address", "node_name", "primary_nn"]
     fieldsets = [
         (
             "Node Details",

--- a/src/meshapi/models.py
+++ b/src/meshapi/models.py
@@ -198,3 +198,8 @@ class Sector(models.Model):
     ssid = models.TextField(default=None, blank=True, null=True)
 
     notes = models.TextField(default=None, blank=True, null=True)
+
+    def __str__(self):
+        if self.ssid:
+            return self.ssid
+        return f"MeshDB Sector ID {self.id}"

--- a/src/meshapi/models.py
+++ b/src/meshapi/models.py
@@ -131,7 +131,7 @@ class Install(models.Model):
         ]
 
     def __str__(self):
-        return f"Install #{str(self.install_number)}"
+        return f"#{str(self.install_number)}"
 
 
 class Link(models.Model):

--- a/src/meshapi/models.py
+++ b/src/meshapi/models.py
@@ -158,6 +158,11 @@ class Link(models.Model):
     description = models.TextField(default=None, blank=True, null=True)
     notes = models.TextField(default=None, blank=True, null=True)
 
+    def __str__(self):
+        if self.from_building.primary_nn and self.to_building.primary_nn:
+            return f"NN{self.from_building.primary_nn} → NN{self.to_building.primary_nn}"
+        return f"MeshDB Link ID {self.id}"
+
 
 class Sector(models.Model):
     class SectorStatus(models.TextChoices):

--- a/src/meshapi/static/admin/admin.css
+++ b/src/meshapi/static/admin/admin.css
@@ -1,0 +1,3 @@
+.inline-group .tabular td.original p {
+    font-size: 12px;
+}

--- a/src/meshapi/static/admin/admin.css
+++ b/src/meshapi/static/admin/admin.css
@@ -1,3 +1,14 @@
 .inline-group .tabular td.original p {
     font-size: 12px;
 }
+/*
+.inline-group .tabular tr.has_original td {
+    padding-top: 0px;
+}*/
+td.original p {
+  visibility: hidden
+}
+
+.inline-group .tabular tr.has_original td {
+    padding-top: 5px;
+}

--- a/src/meshapi/static/admin/install_tabular.css
+++ b/src/meshapi/static/admin/install_tabular.css
@@ -1,10 +1,9 @@
+/* Increase size of titles. Currently unused, but may be useful later. */
 .inline-group .tabular td.original p {
     font-size: 12px;
 }
-/*
-.inline-group .tabular tr.has_original td {
-    padding-top: 0px;
-}*/
+
+/* Hide titles so we can hardcode them into the template */
 td.original p {
   visibility: hidden
 }

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -13,8 +13,8 @@
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
      <thead><tr>
-        <!--Janktown: We're hardcoding Install Number and Link to Install in the template because we're horrible.-->
-       <th>Install Number</th>
+       <!--Blank header to make room for pk-->
+       <th></th>
      {% for field in inline_admin_formset.fields %}
        <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
        {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -32,7 +32,7 @@
              id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
         <!--Janktown: We're hardcoding Install Number and Link to Install in the template because we're horrible.-->
         <td>
-          <strong><a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}">#{{ inline_admin_form.original.pk }}</a></strong>
+          <strong><a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}">{{ inline_admin_form.original }}</a></strong>
         </td>
         {% for fieldset in inline_admin_form %}
           {% for line in fieldset %}

--- a/src/meshapi/templates/admin/install_tabular.html
+++ b/src/meshapi/templates/admin/install_tabular.html
@@ -1,0 +1,60 @@
+{% load i18n admin_urls static admin_modify %}
+<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
+     data-inline-type="tabular"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module {{ inline_admin_formset.classes }}">
+   {% if inline_admin_formset.formset.max_num == 1 %}
+     <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+   {% else %}
+     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+   {% endif %}
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+        <!--Janktown: We're hardcoding Install Number and Link to Install in the template because we're horrible.-->
+       <th>Install Number</th>
+     {% for field in inline_admin_formset.fields %}
+       <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
+       {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+       </th>
+     {% endfor %}
+     {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}<th>{% translate "Delete?" %}</th>{% endif %}
+     </tr></thead>
+
+     <tbody>
+     {% for inline_admin_form in inline_admin_formset %}
+        {% if inline_admin_form.form.non_field_errors %}
+        <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+        {% endif %}
+        <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+             id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+        <!--Janktown: We're hardcoding Install Number and Link to Install in the template because we're horrible.-->
+        <td>
+          <strong><a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}">#{{ inline_admin_form.original.pk }}</a></strong>
+        </td>
+        {% for fieldset in inline_admin_form %}
+          {% for line in fieldset %}
+            {% for field in line %}
+              <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
+              {% if field.is_readonly %}
+                  <p>{{ field.contents }}</p>
+              {% else %}
+                  {{ field.field.errors.as_ul }}
+                  {{ field.field }}
+              {% endif %}
+              </td>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
+          <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
+        {% endif %}
+        </tr>
+     {% endfor %}
+     </tbody>
+   </table>
+</fieldset>
+  </div>
+</div>

--- a/src/meshapi/tests/test_admin_change_view.py
+++ b/src/meshapi/tests/test_admin_change_view.py
@@ -1,0 +1,73 @@
+from django.test import Client, TestCase
+from django.contrib.auth.models import User
+
+from meshapi.models import Building, Install, Link, Member, Sector
+from .sample_data import sample_building, sample_install, sample_member
+
+class TestAdminChangeView(TestCase):
+    c = Client()
+
+    def setUp(self):
+        sample_install_copy = sample_install.copy()
+        self.building_1 = Building(**sample_building)
+        self.building_1.save()
+        sample_install_copy["building"] = self.building_1
+
+        self.building_2 = Building(**sample_building)
+        self.building_2.street_address = "69" + str(self.building_2.street_address)
+        self.building_2.save()
+
+        self.member = Member(**sample_member)
+        self.member.save()
+        sample_install_copy["member"] = self.member
+
+        self.install = Install(**sample_install_copy)
+        self.install.save()
+
+        self.sector = Sector(
+            id=1,
+            name="Vernon",
+            device_name="LAP-120",
+            building=self.building_1,
+            status="Active",
+            azimuth=0,
+            width=120,
+            radius=0.3,
+        )
+        self.sector.save()
+
+        self.link = Link(
+            from_building=self.building_1,
+            to_building=self.building_2,
+            status=Link.LinkStatus.ACTIVE,
+        )
+        self.link.save()
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.c.login(username="admin", password="admin_password")
+
+    def _call(self, route, code):
+        response = self.c.get(route)
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"Call to admin panel route {route} failed. Got code {code}."
+        )
+
+    def test_change_building(self):
+        self._call(f"/admin/meshapi/building/{self.building_1.id}/change/", 200)
+
+    def test_change_member(self):
+        self._call(f"/admin/meshapi/member/{self.member.id}/change/", 200)
+
+    def test_change_install(self):
+        self._call(f"/admin/meshapi/install/{self.install.install_number}/change/", 200)
+
+    def test_change_link(self):
+        self._call(f"/admin/meshapi/link/{self.link.id}/change/", 200)
+
+    def test_change_sector(self):
+        self._call(f"/admin/meshapi/sector/{self.sector.id}/change/", 200)
+

--- a/src/meshapi/tests/test_admin_change_view.py
+++ b/src/meshapi/tests/test_admin_change_view.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from meshapi.models import Building, Install, Link, Member, Sector
 from .sample_data import sample_building, sample_install, sample_member
 
+
 class TestAdminChangeView(TestCase):
     c = Client()
 
@@ -50,11 +51,7 @@ class TestAdminChangeView(TestCase):
 
     def _call(self, route, code):
         response = self.c.get(route)
-        self.assertEqual(
-            code,
-            response.status_code,
-            f"Call to admin panel route {route} failed. Got code {code}."
-        )
+        self.assertEqual(code, response.status_code, f"Call to admin panel route {route} failed. Got code {code}.")
 
     def test_change_building(self):
         self._call(f"/admin/meshapi/building/{self.building_1.id}/change/", 200)
@@ -70,4 +67,3 @@ class TestAdminChangeView(TestCase):
 
     def test_change_sector(self):
         self._call(f"/admin/meshapi/sector/{self.sector.id}/change/", 200)
-

--- a/src/meshapi/tests/test_admin_list_view.py
+++ b/src/meshapi/tests/test_admin_list_view.py
@@ -1,8 +1,9 @@
 from django.test import Client, TestCase
 from django.contrib.auth.models import User
 
+
 # Sanity check to make sure that the list views in the admin panel still work
-# These will often break when you update something in the model and forget to 
+# These will often break when you update something in the model and forget to
 # update the admin panel
 class TestAdminListView(TestCase):
     c = Client()
@@ -15,11 +16,7 @@ class TestAdminListView(TestCase):
 
     def _call(self, route, code):
         response = self.c.get(route)
-        self.assertEqual(
-            code,
-            response.status_code,
-            f"Could not view {route} in the admin panel."
-        )
+        self.assertEqual(code, response.status_code, f"Could not view {route} in the admin panel.")
 
     def test_list_building(self):
         self._call("/admin/meshapi/building/", 200)
@@ -35,4 +32,3 @@ class TestAdminListView(TestCase):
 
     def test_list_sector(self):
         self._call("/admin/meshapi/sector/", 200)
-

--- a/src/meshapi/tests/test_admin_list_view.py
+++ b/src/meshapi/tests/test_admin_list_view.py
@@ -1,0 +1,35 @@
+from django.test import Client, TestCase
+from django.contrib.auth.models import User
+
+class TestJoinForm(TestCase):
+    c = Client()
+
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.c.login(username="admin", password="admin_password")
+
+    def _test_list(self, route, code):
+        response = self.c.get(route)
+        self.assertEqual(
+            code,
+            response.status_code,
+            f"Could not view {route} in the admin panel."
+        )
+
+    def test_list_building(self):
+        self._test_list("/admin/meshapi/building/", 200)
+
+    def test_list_member(self):
+        self._test_list("/admin/meshapi/member/", 200)
+
+    def test_list_install(self):
+        self._test_list("/admin/meshapi/install/", 200)
+
+    def test_list_link(self):
+        self._test_list("/admin/meshapi/link/", 200)
+
+    def test_list_sector(self):
+        self._test_list("/admin/meshapi/sector/", 200)
+

--- a/src/meshapi/tests/test_admin_list_view.py
+++ b/src/meshapi/tests/test_admin_list_view.py
@@ -1,7 +1,10 @@
 from django.test import Client, TestCase
 from django.contrib.auth.models import User
 
-class TestJoinForm(TestCase):
+# Sanity check to make sure that the list views in the admin panel still work
+# These will often break when you update something in the model and forget to 
+# update the admin panel
+class TestAdminListView(TestCase):
     c = Client()
 
     def setUp(self):
@@ -10,7 +13,7 @@ class TestJoinForm(TestCase):
         )
         self.c.login(username="admin", password="admin_password")
 
-    def _test_list(self, route, code):
+    def _call(self, route, code):
         response = self.c.get(route)
         self.assertEqual(
             code,
@@ -19,17 +22,17 @@ class TestJoinForm(TestCase):
         )
 
     def test_list_building(self):
-        self._test_list("/admin/meshapi/building/", 200)
+        self._call("/admin/meshapi/building/", 200)
 
     def test_list_member(self):
-        self._test_list("/admin/meshapi/member/", 200)
+        self._call("/admin/meshapi/member/", 200)
 
     def test_list_install(self):
-        self._test_list("/admin/meshapi/install/", 200)
+        self._call("/admin/meshapi/install/", 200)
 
     def test_list_link(self):
-        self._test_list("/admin/meshapi/link/", 200)
+        self._call("/admin/meshapi/link/", 200)
 
     def test_list_sector(self):
-        self._test_list("/admin/meshapi/sector/", 200)
+        self._call("/admin/meshapi/sector/", 200)
 

--- a/src/meshapi/tests/test_admin_search_view.py
+++ b/src/meshapi/tests/test_admin_search_view.py
@@ -1,0 +1,69 @@
+from django.test import Client, TestCase
+from django.contrib.auth.models import User
+
+from meshapi.models import Building, Install, Link, Member, Sector
+from .sample_data import sample_building, sample_install, sample_member
+
+
+class TestAdminChangeView(TestCase):
+    c = Client()
+
+    def setUp(self):
+        sample_install_copy = sample_install.copy()
+        self.building_1 = Building(**sample_building)
+        self.building_1.save()
+        sample_install_copy["building"] = self.building_1
+
+        self.building_2 = Building(**sample_building)
+        self.building_2.street_address = "69" + str(self.building_2.street_address)
+        self.building_2.save()
+
+        self.member = Member(**sample_member)
+        self.member.save()
+        sample_install_copy["member"] = self.member
+
+        self.install = Install(**sample_install_copy)
+        self.install.save()
+
+        self.sector = Sector(
+            id=1,
+            name="Vernon",
+            device_name="LAP-120",
+            building=self.building_1,
+            status="Active",
+            azimuth=0,
+            width=120,
+            radius=0.3,
+        )
+        self.sector.save()
+
+        self.link = Link(
+            from_building=self.building_1,
+            to_building=self.building_2,
+            status=Link.LinkStatus.ACTIVE,
+        )
+        self.link.save()
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin", password="admin_password", email="admin@example.com"
+        )
+        self.c.login(username="admin", password="admin_password")
+
+    def _call(self, route, code):
+        response = self.c.get(route)
+        self.assertEqual(code, response.status_code, f"Call to admin panel route {route} failed. Got code {code}.")
+
+    def test_search_building(self):
+        self._call("/admin/meshapi/building/?q=1", 200)
+
+    def test_search_member(self):
+        self._call("/admin/meshapi/member/?q=1", 200)
+
+    def test_search_install(self):
+        self._call("/admin/meshapi/install/?q=1", 200)
+
+    def test_search_link(self):
+        self._call("/admin/meshapi/link/?q=1", 200)
+
+    def test_search_sector(self):
+        self._call("/admin/meshapi/sector/?q=1", 200)

--- a/src/meshdb/settings.py
+++ b/src/meshdb/settings.py
@@ -103,7 +103,7 @@ ROOT_URLCONF = "meshdb.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, "meshdb/templates")],
+        "DIRS": [os.path.join(BASE_DIR, "meshdb/templates"), os.path.join(BASE_DIR, "meshapi/templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
Right now, we've got some problems with buildings and such not having street names, which are used as the primary title in the Admin Panel, Causing them to be unselectable. See #202.

This'll make the List View always use "__str__" in the models, which should guarantee that _something_ shows up for the row.

Side effect of this: Sometimes the information in the following columns can be redundant.

Example: 
![image](https://github.com/WillNilges/meshdb/assets/42927786/598c86c9-2521-4fbf-b25b-06c17abbb6da)


Changes:
- Buildings, instead of always using their street name as primary view, will now use Building Name, falling back on Street Address, BIN, and finally MeshDB Building ID.
- Links, instead of using MeshDB Link IDs, will use `NN to NN`, falling back on MeshDB Link IDs.
- Sectors, instead of using MeshDB Sector IDs, will use SSID, falling back on MeshDB Sector IDs.