### PR TITLE
Add Beta disclaimer to meshdb

### DIFF
--- a/src/meshdb/templates/admin/read_only_warning_box.html
+++ b/src/meshdb/templates/admin/read_only_warning_box.html
@@ -1,4 +1,4 @@
-<p class="warning-box">
+<!--<p class="warning-box">
     Warning: <strong>This project is in Beta.</strong> You may experience instability,
     encounter errors, and find bugs. Everything, from the data model, to the user
     interface, to the API is <strong>subject to change.</strong> Your feedback is
@@ -10,4 +10,17 @@
     spreadsheet. Edits are enabled in the UI, however <b>changes will not be preserved</b>,
     and will be replaced with the spreadsheet content each night. Changes to metadata such as
     user logins, permissions groups, app tokens, and webhook config will be preserved.
+</p>-->
+
+<p class="warning-box">
+    Warning: <strong>This project is in Beta</strong> and subject to change. You
+    may experience bugs. The data on this site is currently a read-only copy of
+    the "New Node Form Responses" spreadsheet. Edits are enabled in the UI, however
+    <b>changes will not be preserved</b>, and will be replaced with the spreadsheet
+    content each night. Changes to metadata such as user logins, permissions groups,
+    app tokens, and webhook config will be preserved.
+    <br>
+    Your feedback is appreciated! If you experience problems, or have a suggestion,
+    please let us know in the <a href="https://nycmesh.slack.com/archives/C06GW3Q92TY">#meshdb</a>
+    channel in Slack, or open an issue on <a href="https://github.com/willnilges/meshdb">GitHub</a>.
 </p>

--- a/src/meshdb/templates/admin/read_only_warning_box.html
+++ b/src/meshdb/templates/admin/read_only_warning_box.html
@@ -1,5 +1,12 @@
 <p class="warning-box">
-    Warning: The data on this site is currently a read-only copy of the "New Node Form Responses"
+    Warning: <strong>This project is in Beta.</strong> You may experience instability,
+    encounter errors, and find bugs. Everything, from the data model, to the user
+    interface, to the API is <strong>subject to change.</strong> Your feedback is
+    appreciated! If you find a problem, or have a suggestion, please let us know in
+    the <a href="https://nycmesh.slack.com/archives/C06GW3Q92TY">#meshdb</a> channel
+    in Slack, or open an issue on <a href="https://github.com/willnilges/meshdb">GitHub</a>.
+    <br/>
+    The data on this site is currently a read-only copy of the "New Node Form Responses"
     spreadsheet. Edits are enabled in the UI, however <b>changes will not be preserved</b>,
     and will be replaced with the spreadsheet content each night. Changes to metadata such as
     user logins, permissions groups, app tokens, and webhook config will be preserved.


### PR DESCRIPTION
Adds a disclaimer to the warning at the top of MeshDB.

![image](https://github.com/WillNilges/meshdb/assets/42927786/ba97849d-d5d5-404e-be36-53b36da90e5c)
