### PR TITLE
Map improvements

### DIFF
--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -385,6 +385,9 @@ class TestViewsGetUnauthenticated(TestCase):
     def test_link_data(self):
         links = []
 
+        member = Member(name="Fake Name")
+        member.save()
+
         grand = Node(
             network_number=1934,
             status=Node.NodeStatus.ACTIVE,
@@ -477,6 +480,23 @@ class TestViewsGetUnauthenticated(TestCase):
             status=Node.NodeStatus.ACTIVE,
         )
         random.save()
+        random_building = Building(
+            latitude=0,
+            longitude=0,
+            address_truth_sources=[],
+            primary_node=random,
+        )
+        random_building.save()
+        random_install = Install(
+            install_number=123,
+            building=random_building,
+            node=random,
+            status=Install.InstallStatus.ACTIVE,
+            request_date=datetime.date(2015, 3, 15),
+            member=member,
+        )
+        random_install.save()
+        random.save()
         random_omni = Device(
             node=random,
             model="OmniTik",
@@ -486,6 +506,52 @@ class TestViewsGetUnauthenticated(TestCase):
             longitude=0,
         )
         random_omni.save()
+
+        random_addl_building = Building(
+            latitude=0,
+            longitude=0,
+            address_truth_sources=[],
+            primary_node=random,
+        )
+        random_addl_building.save()
+
+        random_addl_install = Install(
+            install_number=56789,
+            building=random_addl_building,
+            node=random,
+            status=Install.InstallStatus.ACTIVE,
+            request_date=datetime.date(2015, 3, 15),
+            member=member,
+        )
+        random_addl_install.save()
+
+        random_addl_install_2 = Install(
+            install_number=56790,
+            building=random_addl_building,
+            node=random,
+            status=Install.InstallStatus.ACTIVE,
+            request_date=datetime.date(2015, 3, 15),
+            member=member,
+        )
+        random_addl_install_2.save()
+
+        random_addl_building_inactive = Building(
+            latitude=0,
+            longitude=0,
+            address_truth_sources=[],
+            primary_node=random,
+        )
+        random_addl_building_inactive.save()
+
+        random_addl_install_inactive = Install(
+            install_number=56791,
+            building=random_addl_building_inactive,
+            node=random,
+            status=Install.InstallStatus.INACTIVE,
+            request_date=datetime.date(2015, 3, 15),
+            member=member,
+        )
+        random_addl_install_inactive.save()
 
         inactive = Node(
             network_number=123456,
@@ -602,6 +668,11 @@ class TestViewsGetUnauthenticated(TestCase):
                     "from": 1934,
                     "to": 123,
                     "status": "planned",
+                },
+                {
+                    "from": 56789,
+                    "to": 123,
+                    "status": "active",
                 },
             ],
         )

--- a/src/meshapi/tests/test_map_endpoints.py
+++ b/src/meshapi/tests/test_map_endpoints.py
@@ -97,6 +97,18 @@ class TestViewsGetUnauthenticated(TestCase):
                 notes="Spreadsheet notes:\nHub: LiteBeamLR to SN1 plus kiosk failover",
             )
         )
+        ap_device = Device(
+            id=123456,
+            node=nodes[-1],
+            name=f"Northwest AP",
+            model="Unknown",
+            type=Device.DeviceType.AP,
+            install_date=datetime.date(2024, 1, 27),
+            status=Device.DeviceStatus.ACTIVE,
+            latitude=40.724863,
+            longitude=-73.987879,
+        )
+        ap_device.save()
 
         buildings.append(
             Building(
@@ -260,6 +272,17 @@ class TestViewsGetUnauthenticated(TestCase):
                     "coordinates": [-73.9917741, 40.6962265, 66.0],
                     "requestDate": 1706331600000,
                     "roofAccess": True,
+                    "panoramas": [],
+                },
+                {
+                    "id": 1123456,
+                    "name": "Northwest AP",
+                    "status": "Installed",
+                    "coordinates": [-73.987879, 40.724863, None],
+                    "requestDate": 1706331600000,
+                    "installDate": 1706331600000,
+                    "roofAccess": False,
+                    "notes": "AP",
                     "panoramas": [],
                 },
             ],

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -52,8 +52,12 @@ class MapDataNodeList(generics.ListAPIView):
             ~Q(status=Node.NodeStatus.INACTIVE) & Q(installs__status__in=ALLOWED_INSTALL_STATUSES)
         ):
             if node.network_number not in covered_nns:
-                # Arbitrarily pick a representative install for the details of the "Fake" node
-                representative_install = node.installs.all()[0]
+                # Arbitrarily pick a representative install for the details of the "Fake" node,
+                # preferring active installs if possible
+                representative_install = node.installs.filter(status=Install.InstallStatus.ACTIVE).first()
+                if not representative_install:
+                    representative_install = node.installs.first()
+
                 all_installs.append(
                     Install(
                         install_number=node.network_number,

--- a/src/meshapi/views/map.py
+++ b/src/meshapi/views/map.py
@@ -77,10 +77,13 @@ class MapDataLinkList(generics.ListAPIView):
     pagination_class = None
     queryset = (
         Link.objects.exclude(status__in=[Link.LinkStatus.INACTIVE])
-        .exclude(from_device__status=Device.DeviceStatus.INACTIVE)
-        .exclude(to_device__status=Device.DeviceStatus.INACTIVE)
         .exclude(to_device__node__status=Node.NodeStatus.INACTIVE)
         .exclude(from_device__node__status=Node.NodeStatus.INACTIVE)
+        # TODO: Possibly re-enable the below filters? They make make the map arguably more accurate,
+        #  but less consistent with the current one by removing links between devices that are
+        #  inactive in UISP
+        # .exclude(from_device__status=Device.DeviceStatus.INACTIVE)
+        # .exclude(to_device__status=Device.DeviceStatus.INACTIVE)
     )
 
 


### PR DESCRIPTION
Builds on #223 with misc fixes to the map data endpoints:
- Don't filter out links between offline devices (even though this makes the map more accurate, since it makes it look less like the current map)
- Add map links for nodes like NN4734 which have cable runs to adjacent buildings
- Add fake nodes for standalone AP devices so that they show up
- Huge speed improvements by using `.prefetch_related()` to cut down on the number of DB queries