### PR TITLE
Misc KML fixes

### DIFF
--- a/src/meshapi/tests/test_kml_endpoint.py
+++ b/src/meshapi/tests/test_kml_endpoint.py
@@ -143,6 +143,9 @@ class TestKMLEndpoint(TestCase):
         # TODO: Actually assert real things here in a less brittle way,
         #  once fastkml is actually capable of parsing its own outputs
         assert len(kml_tree[0]) == 6  # 4 styles and 2 folders
-        assert len(kml_tree[0][4]) == 7  # 5 borough folders and "Other" + 1 for "name" tag
-        assert len(kml_tree[0][4][6]) == 7  # 6 nodes, all in the "Other" folder + 1 for "name" tag
-        assert len(kml_tree[0][5]) == 6  # 5 links + 1 for "name" tag
+        assert len(kml_tree[0][4]) == 3  # "Active" and "Inactive" node folders + 1 for "name" tag
+        assert len(kml_tree[0][4][1]) == 7  # 5 borough folders and "Other" + 1 for "name" tag
+        assert len(kml_tree[0][4][1][6]) == 13  # 6 installs and 6 NNs, all in the "Other" folder + 1 for "name" tag
+        assert len(kml_tree[0][5]) == 3  # "Active" and "Inactive" link folders + 1 for "name" tag
+        assert len(kml_tree[0][5][1]) == 5  # 4 active links + 1 for "name" tag
+        assert len(kml_tree[0][5][2]) == 2  # 1 inactive links + 1 for "name" tag

--- a/src/meshapi/views/geography.py
+++ b/src/meshapi/views/geography.py
@@ -194,7 +194,7 @@ class WholeMeshKML(APIView):
                         install.node.latitude,
                         install.node.altitude or DEFAULT_ALTITUDE,
                     ),
-                    install.node.status == Node.NodeStatus.ACTIVE,
+                    False,
                     install.node.status,
                     roof_access=False,
                 )

--- a/src/meshapi/views/geography.py
+++ b/src/meshapi/views/geography.py
@@ -173,7 +173,7 @@ class WholeMeshKML(APIView):
                         ]
                     ),
                     altitude_mode=AltitudeMode.absolute,
-                    extrude=True,
+                    extrude=False,
                 ),
             )
 

--- a/src/meshapi/views/geography.py
+++ b/src/meshapi/views/geography.py
@@ -166,9 +166,9 @@ class WholeMeshKML(APIView):
                                 link.from_device.altitude or DEFAULT_ALTITUDE,
                             ),
                             (
-                                link.from_device.longitude,
-                                link.from_device.latitude,
-                                link.from_device.altitude or DEFAULT_ALTITUDE,
+                                link.to_device.longitude,
+                                link.to_device.latitude,
+                                link.to_device.altitude or DEFAULT_ALTITUDE,
                             ),
                         ]
                     ),


### PR DESCRIPTION
Builds on #223, to add misc KML fixes based on Olivier's feedback:
- Remove "black shading to ground"
- Fix: links don't appear because of to/from typo
- Speed up query using `prefetch_related()`
- Add sub-folders for active and inactive nodes/links
- Add map dots for NN as well as Install numbers (to make searching easier)