### PR TITLE
Add command to scramble member data

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ Run `psql`
 psql -U meshdb
 ```
 
+### Backups
+
+**The Quick 'n Dirty Way**
+
+Export:
+
+```
+docker exec -it meshdb-postgres-1 pg_dump -d meshdb -U meshdb >> Downloads/meshdb_dev.sql
+```
+
+Import:
+
+```
+cat ~/Downloads/meshdb_dev.sql | docker exec -i meshdb-postgres-1 psql -U meshdb
+```
+
 ## Invoke.py Commands
 
 For convenience, this package uses [invoke](https://www.pyinvoke.org/) to wrap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "django-filter==24.1",
     # FIXME: Go back to PyPI when https://github.com/bhch/django-jsonform/pull/162 is merged
     "django-jsonform@git+https://github.com/willnilges/django-jsonform.git@51cbed42ccdaec81a35c97a919d054e2c9ca0207",
+    "faker==24.3.*",
 ]
 
 [project.optional-dependencies]

--- a/src/meshapi/admin.py
+++ b/src/meshapi/admin.py
@@ -434,8 +434,8 @@ class NodeAdminForm(forms.ModelForm):
 class NodeAdmin(admin.ModelAdmin):
     form = NodeAdminForm
     search_fields = ["network_number__iexact", "name__icontains", "buildings__street_address__icontains"]
-    list_filter = ["status", ("name", admin.EmptyFieldListFilter)]
-    list_display = ["__network_number__", "name", "status", "address"]
+    list_filter = ["status", ("name", admin.EmptyFieldListFilter), "install_date", "abandon_date"]
+    list_display = ["__network_number__", "name", "status", "address", "install_date"]
     fieldsets = [
         (
             "Details",

--- a/src/meshapi/management/commands/scramble_members.py
+++ b/src/meshapi/management/commands/scramble_members.py
@@ -5,6 +5,7 @@ from random import randrange
 
 from meshapi.models import Member, Install
 
+
 # Uses faker to get fake names, emails, and phone numbers
 # TODO: Instead of modifying real data, generate a completely fake database from
 # scratch :)
@@ -32,7 +33,7 @@ class Command(BaseCommand):
             for member in members:
                 member.name = fake.name()
                 member.primary_email_address = f"{member.name.replace(' ', '').lower()}@gmail.com"
-                member.stripe_email_address
+                member.stripe_email_address = ""
                 member.additional_email_addresses = []
                 member.phone_number = fake.phone_number()
                 member.slack_handle = ""

--- a/src/meshapi/management/commands/scramble_members.py
+++ b/src/meshapi/management/commands/scramble_members.py
@@ -1,0 +1,51 @@
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+from faker import Faker
+from random import randrange
+
+from meshapi.models import Member, Install
+
+# Uses faker to get fake names, emails, and phone numbers
+# TODO: Instead of modifying real data, generate a completely fake database from
+# scratch :)
+class Command(BaseCommand):
+    help = "Updates all members with fake name, email, and phone number. Clears notes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--skip-members",
+            action="store_true",
+            help="Skip scrambling members",
+        )
+        parser.add_argument(
+            "--skip-installs",
+            action="store_true",
+            help="Skip scrambling installs",
+        )
+
+    def handle(self, *args, **options):
+        print("Scrambling members...")
+        members = Member.objects.all()
+        fake = Faker()
+        if not options["skip_members"]:
+            print("Scrambling members...")
+            for member in members:
+                member.name = fake.name()
+                member.primary_email_address = f"{member.name.replace(' ', '').lower()}@gmail.com"
+                member.stripe_email_address
+                member.additional_email_addresses = []
+                member.phone_number = fake.phone_number()
+                member.slack_handle = ""
+                member.notes = fake.text()
+                member.save()
+                print(f"{member.id} - {member.name}")
+
+        if not options["skip_installs"]:
+            print("Scrambling installs...")
+            installs = Install.objects.all()
+            for install in installs:
+                install.unit = randrange(100)
+                install.save()
+                print(install.install_number)
+
+        print("Done")


### PR DESCRIPTION
Randomizes the name, phone number, and email addresses of member objects, along with apartment numbers in installs, using [Faker](https://faker.readthedocs.io/en/master/index.html). This allows us to create data that is safe to show off/demo/give to developers while protecting peoples' identities. Notably, this is all still real buildings, nodes, devices.

Potential for the future: Generate install data completely from scratch. This requires that there be data in the database already.