### PR TITLE
Mock out requests in panoramas tests

### DIFF
--- a/src/meshapi/tests/test_update_panos_github.py
+++ b/src/meshapi/tests/test_update_panos_github.py
@@ -1,9 +1,12 @@
 import os
-from django.test import Client, TestCase
+from unittest.mock import MagicMock, patch
+
 from django.contrib.auth.models import User
+from django.test import Client, TestCase
 
 from meshapi.models import Building, Install, Link, Member, Sector
 from meshapi.views import panoramas
+
 from .sample_data import sample_building, sample_install, sample_member
 
 
@@ -93,7 +96,20 @@ class TestPanoAuthentication(TestCase):
         )
 
     # This tests the endpoint, but not the actual full pipeline.
-    def test_update_panoramas_authenticated(self):
+    @patch("meshapi.views.os.environ.get")
+    @patch("meshapi.views.requests.get")
+    def test_update_panoramas_authenticated(self, mock_requests, mock_os):
+        fake_dir = "data/panoramas"
+        mock_os.return_value = fake_dir
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "commit": {"commit": {"tree": {"sha": "4"}}},
+            "tree": [{"type": "blob", "path": f"{fake_dir}/lol.txt"}],
+        }
+        mock_requests.return_value = mock_response
+
         response = self.admin_c.get("/api/v1/update-panoramas/")
         code = 200
         self.assertEqual(
@@ -106,22 +122,12 @@ class TestPanoAuthentication(TestCase):
 class TestPanoUtils(TestCase):
     def setUp(self):
         # Check that we have all the environment variables we need
-        self.owner = os.environ.get("PANO_REPO_OWNER")
-        self.repo = os.environ.get("PANO_REPO")
-        self.branch = os.environ.get("PANO_BRANCH")
-        self.directory = os.environ.get("PANO_DIR")
-        self.host_url = os.environ.get("PANO_HOST")
-        self.token = os.environ.get("PANO_GITHUB_TOKEN")
-
-        if (
-            not self.owner
-            or not self.repo
-            or not self.branch
-            or not self.directory
-            or not self.host_url
-            or not self.token
-        ):
-            raise Exception("Did not find environment variables.")
+        self.owner = os.environ.get("PANO_REPO_OWNER") or "nycmeshnet"
+        self.repo = os.environ.get("PANO_REPO") or "node-db"
+        self.branch = os.environ.get("PANO_BRANCH") or "master"
+        self.directory = os.environ.get("PANO_DIR") or "data/panoramas"
+        self.host_url = os.environ.get("PANO_HOST") or "http://example.com"
+        self.token = os.environ.get("PANO_GITHUB_TOKEN") or "4"
 
     def test_parse_pano_title(self):
         test_cases = {
@@ -157,9 +163,21 @@ class TestPanoUtils(TestCase):
     # Also this API likes to give me 500s and it would be nice to know if that was
     # a common enough thing to disrupt tests. I guess this is designed to detect
     # flakiness
-    def test_github_API(self):
+    @patch("meshapi.views.requests.get")
+    def test_github_API(self, mock_requests):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "commit": {"commit": {"tree": {"sha": "4"}}},
+            "tree": [{"type": "blob", "path": f"{self.directory}/lol.txt"}],
+        }
+        mock_requests.return_value = mock_response
+
         head_tree_sha = panoramas.get_head_tree_sha(self.owner, self.repo, self.branch)
         assert head_tree_sha is not None
+        assert head_tree_sha == "4"
 
         panorama_files = panoramas.list_files_in_git_directory(self.owner, self.repo, self.directory, head_tree_sha)
         assert panorama_files is not None
+        assert len(panorama_files) == 1
+        assert panorama_files[0] == "lol.txt"


### PR DESCRIPTION
Resolve #276 by mocking out calls to `requests.get` and `os.environ.get`